### PR TITLE
Refactory factory methods to `ipsdk` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ factory function.
 import ipsdk
 
 # Create a connection to Itential Platform
-server = ipsdk.client.platform(
+server = ipsdk.platform(
     host="platform.itential.com",
     user="admin@pronghorn",
     password="admin"
 )
 
 # Set a GET request to the server
-res = platform.get("/whoami")
+res = server.get("/whoami")
 
 # Print the response information to stdout
-print(response.status_code, response.body)
+print(res.status_code, res.body)
 ```
 
 Different functions provide different configuation options.
 
 ##  Configuration via Environment Variables
 
-You can override constructor parameters using the following environment variables:
+You can set constructor parameters using the following environment variables:
 
 | Variable                 | Description               | Platform  | Gateway   | Cloud     |
 |--------------------------|---------------------------|-----------|-----------|-----------|

--- a/ipsdk/__init__.py
+++ b/ipsdk/__init__.py
@@ -3,9 +3,9 @@
 
 import logging
 
-from . import client
+from .client import platform, gateway, cloud
 
-__all__ = [client]
+__all__ = [platform, gateway, cloud]
 
 # Configure global logging
 logging_message_format = '%(asctime)s: %(levelname)s: %(message)s'

--- a/ipsdk/client.py
+++ b/ipsdk/client.py
@@ -4,6 +4,8 @@
 import os
 import logging
 
+from functools import partial
+
 from . import http
 from . import stringutils
 
@@ -150,6 +152,16 @@ def cloud(host=None, port=0, use_tls=True, verify=True, client_id=None, client_s
         timeout=stringutils.string_to_int(os.getenv("ITENTIAL_TIMEOUT", timeout)),
     )
 
+def get(f, key, value, default):
+    if value is None:
+        value = os.getenv(f"ITENTIAL_{key}".upper(), default)
+    return f(value)
+
+
+getstr = partial(get, stringutils.tostr)
+getint = partial(get, stringutils.toint)
+getbool = partial(get, stringutils.tobool)
+
 
 def platform(host=None, port=0, use_tls=True, verify=True, user="admin", password="admin", client_id=None, client_secret=None, timeout=30):
     """
@@ -184,15 +196,15 @@ def platform(host=None, port=0, use_tls=True, verify=True, user="admin", passwor
         Platform: An initialized Platform connection instance.
     """
     return Platform(
-        host=os.getenv("ITENTIAL_HOST", host),
-        port=stringutils.string_to_int(os.getenv("ITENTIAL_PORT", port)),
-        use_tls=stringutils.string_to_bool(os.getenv("ITENTIAL_USE_TLS", use_tls)),
-        verify=stringutils.string_to_bool(os.getenv("ITENTIAL_VERIFY", verify)),
-        user=os.getenv("ITENTIAL_USER", user),
-        password=os.getenv("ITENTIAL_PASSWORD", password),
-        client_id=os.getenv("ITENTIAL_CLIENT_ID", client_id),
-        client_secret=os.getenv("ITENTIAL_CLIENT_SECRET", client_secret),
-        timeout=stringutils.string_to_int(os.getenv("ITENTIAL_TIMEOUT", timeout))
+        host=getstr("host", host, None),
+        port=getint("port", port, 0),
+        use_tls=getbool("use_tls", use_tls, True),
+        verify=getbool("verify", verify, True),
+        user=getstr("user", user, "admin"),
+        password=getstr("password", password, "admin"),
+        client_id=getstr("client_id", client_id, None),
+        client_secret=getstr("client_secret", client_secret, None),
+        timeout=getint("timeout", timeout, 30),
     )
 
 

--- a/ipsdk/stringutils.py
+++ b/ipsdk/stringutils.py
@@ -4,7 +4,13 @@
 from typing import Optional
 
 
-def string_to_bytes(s: str, encoding: str = "utf-8") -> bytes:
+def tostr(s: str) -> str:
+    if s is not None:
+        s = str(s)
+    return s
+
+
+def tobytes(s: str, encoding: str = "utf-8") -> bytes:
     """
     Convert a string into bytes using the specified encoding.
 
@@ -18,7 +24,7 @@ def string_to_bytes(s: str, encoding: str = "utf-8") -> bytes:
     return s.encode(encoding)
 
 
-def string_to_int(value: str) -> int:
+def toint(value: str) -> int:
     """
     Convert a string representation of an integer to an int type.
 
@@ -31,7 +37,7 @@ def string_to_int(value: str) -> int:
     return int(value)
 
 
-def string_to_bool(value: Optional[str]) -> bool:
+def tobool(value: Optional[str]) -> bool:
     """
     Convert a string representation of a boolean to a bool type.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,6 @@
 
+import sys
+
 import pytest
 from unittest.mock import MagicMock
 from types import SimpleNamespace
@@ -10,7 +12,6 @@ class MockConnection:
         self.session = MagicMock()
 
 # Mock dependencies
-import sys
 module = sys.modules[__name__]
 setattr(module, 'http', SimpleNamespace(Connection=MockConnection, make_url=lambda *a, **kw: "https://mock.url"))
 setattr(module, 'stringutils', SimpleNamespace(

--- a/tests/test_stringutils.py
+++ b/tests/test_stringutils.py
@@ -3,11 +3,9 @@
 
 from ipsdk import stringutils
 
-def test_string_to_bool_cases():
-    assert stringutils.string_to_bool("true")
-    assert stringutils.string_to_bool("yes")
-    assert not stringutils.string_to_bool("false")
-    assert not stringutils.string_to_bool("no")
-    assert not stringutils.string_to_bool(None)
-
-
+def test_tobool():
+    assert stringutils.tobool("true")
+    assert stringutils.tobool("yes")
+    assert not stringutils.tobool("false")
+    assert not stringutils.tobool("no")
+    assert not stringutils.tobool(None)


### PR DESCRIPTION
The factory methods are now available as toplevel functions from `ipsdk` making them easily accesible.  This change also updates the order of operations such that environment variables no longer override values passed directly to the factory function.