### PR TITLE
Updates base api path for gateway

### DIFF
--- a/ipsdk/client.py
+++ b/ipsdk/client.py
@@ -244,4 +244,5 @@ def gateway(host=None, port=0, use_tls=True, verify=True, user="admin@itential",
         user=getstr("user", user, "admin"),
         password=getstr("password", password, "admin"),
         timeout=getint("timeout", timeout, 30),
+        base_path="/api/v2.0",
     )


### PR DESCRIPTION
The base api path was not set and therefore it required the full api
path.   The base path is now properly set to `/api/v2.0`.  Going
forward, all API requests will prepend the base path to the URI.