### PR TITLE
Fix pre-merge pipeline

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -27,4 +27,4 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run the permerge target
-        run: make permerge
+        run: make premerge


### PR DESCRIPTION
The premerge pipeline had a typo in the Makefile target.  This commit corrects the problem and the pipeline should be running again.