### PR TITLE
Consolidate logging to the logger module

### DIFF
--- a/ipsdk/__init__.py
+++ b/ipsdk/__init__.py
@@ -6,18 +6,19 @@ import logging
 from .platform import platform_factory
 from .gateway import gateway_factory
 
+__version__ = "devel"
+
 __all__ = (platform_factory, gateway_factory)
+
 
 # Configure global logging
 logging_message_format = '%(asctime)s: %(levelname)s: %(message)s'
 logging.basicConfig(format=logging_message_format)
-logging.getLogger("ipsdk").setLevel(logging.CRITICAL)
+logging.getLogger("ipsdk").setLevel(100)
 
-logger = logging.getLogger(__name__)
 
 def set_logging_level(lvl: int):
-    """
-    Set logging level for all loggers in the current Python process.
+    """Set logging level for all loggers in the current Python process.
 
     Args:
         level (int): Logging level (e.g., logging.INFO, logging.DEBUG)

--- a/ipsdk/gateway.py
+++ b/ipsdk/gateway.py
@@ -1,12 +1,10 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import logging
 import traceback
 
 from . import http
-
-logger = logging.getLogger(__name__)
+from . import logger
 
 
 class Gateway(http.Connection):

--- a/ipsdk/http.py
+++ b/ipsdk/http.py
@@ -3,7 +3,6 @@
 
 import abc
 import json
-import logging
 import traceback
 
 import urllib.parse
@@ -13,8 +12,7 @@ from typing import Union
 
 import httpx
 
-
-logger = logging.getLogger(__name__)
+from . import logger
 
 
 def send_request(method, url, headers=None, data=None, params=None, timeout=None,

--- a/ipsdk/jsonutils.py
+++ b/ipsdk/jsonutils.py
@@ -2,13 +2,11 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import json
-import logging
 import traceback
 
 from typing import Union
 
-
-logger = logging.getLogger(__name__)
+from . import logger
 
 
 def loads(s: str) -> Union[dict, list]:

--- a/ipsdk/logger.py
+++ b/ipsdk/logger.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import logging
+
+from functools import partial
+
+
+def log(lvl: int, msg: str):
+    """Send the log message with the specified level
+
+    This function will send the log message to the logger with the specified
+    logging level.  This function should not be direclty invoked.  Use one
+    of the partials to send a log message with a given level.
+
+    Args:
+        lvl (int): The logging level of the message
+        msg (str): The message to write to the logger
+    """
+    logging.getLogger("ipsdk").log(lvl, msg)
+
+
+debug = partial(log, logging.DEBUG)
+info = partial(log, logging.INFO)
+warning = partial(log, logging.WARNING)
+error = partial(log, logging.ERROR)
+critical = partial(log, logging.CRITICAL)

--- a/ipsdk/platform.py
+++ b/ipsdk/platform.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import logging
 import traceback
 
 from . import jsonutils
 from . import http
-
-logger = logging.getLogger(__name__)
+from . import logger
 
 
 class Platform(http.Connection):


### PR DESCRIPTION
Each module implemented its own logging.  This change centralized the logging functions into the logger module and makes it available for all modules.  This will help to keep logging consistent.