### PR TITLE
Transform data to JSON string

### DIFF
--- a/ipsdk/connection.py
+++ b/ipsdk/connection.py
@@ -10,6 +10,7 @@ import httpx
 
 from . import logger
 from . import metadata
+from . import jsonutils
 
 
 class HTTPMethod:
@@ -153,6 +154,9 @@ class Connection(ConnectionBase):
             self.authenticate()
             self.authenticated = True
 
+        if isinstance(data, (dict, list)):
+            data = jsonutils.dumps(data)
+
         request = self._build_request(
             method=method,
             url=url,
@@ -244,6 +248,9 @@ class AsyncConnection(ConnectionBase):
         if self.authenticated is False:
             await self.authenticate()
             self.authenticated = True
+
+        if isinstance(data, (dict, list)):
+            data = jsonutils.dumps(data)
 
         request = self._build_request(
             method=method,

--- a/ipsdk/jsonutils.py
+++ b/ipsdk/jsonutils.py
@@ -23,3 +23,19 @@ def loads(s: str) -> Union[dict, list]:
     except:
         logger.error(traceback.format_exc())
         raise
+
+
+def dumps(o: Union[dict, list]) -> str:
+    """Convert a dict or list to a JSON string
+
+    Args:
+        o (list, dict): The list or dict object to dump to a string
+
+    Returns:
+        A JSON string representation
+    """
+    try:
+        return json.dumps(o)
+    except:
+        logger.error(traceback.format_exc())
+        raise


### PR DESCRIPTION
When calling a method that includes the `data` keyword argument, the method will now autmoatically transform any data that is of type `list` or `dict` to a JSON string before sending to the server.