### PR TITLE
Update method args and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,38 @@ async def main():
 
     res = await p.get("/adapters")
 
-async def asyncrun():
-    res = await p.get("/adapters")
-    print(res)
-
 if __name__ == "__main__":
     asyncio.run(main())
 ```
 
 The connection object supports the following HTTP methods:
 
-- `GET`
-- `POST`
-- `PUT`
-- `DELETE`
-- `PATCH`
+- `GET` - Sends a HTTP GET request to the server and returns the results
+- `POST` - Sends a HTTP POST request to the server and returns the results
+- `PUT` - Sends a HTTP PUT request to the server and returns the results
+- `DELETE` - Sends a HTTP DELETE request to the server and returns the results
+- `PATCH` - Sends a HTTP PATCH request to the server and returns the resutls
+
+The following table shows the keyworkd arguments for each HTTP method:
+
+ | Keyword  | `GET`         | `POST`   | `PUT`    | `DELETE`      | `PATCH`  |
+ |----------|---------------|----------|----------|---------------|----------|
+ | `path`   | Required      | Required | Required | Required      | Required |
+ | `params` | Optional      | Optional | Optional | Optional      | Optional |
+ | `json`   | Not Supported | Optional | Optional | Not Supported | Optional |
+
+The `path` argument specifies the relative path of the URI.   This value is
+prepended to the base URL.  The base URL for Itential Platform is `<host>` and
+the base URL for Itential Automation Gateway is `<host>/api/v2.0`.
+
+The `params` argument accepts a `dict` object that is transformed into the URL
+query string.  For example, if `params={"foo": "bar"}` the resulting query
+string would be `?foo=bar`
+
+The `json` argument accepts the payload to send in the requeset as JSON.  This
+argument accepts either a `list` or `dict` object.  When specified, the data
+will automatically be converted to a JSON string and the `Content-Type` and
+`Accept` headers will be set to `application/json`.
 
 ## Configuration
 

--- a/ipsdk/__init__.py
+++ b/ipsdk/__init__.py
@@ -4,6 +4,7 @@
 import logging
 
 from . import metadata
+
 from .platform import platform_factory
 from .gateway import gateway_factory
 
@@ -18,12 +19,22 @@ logging.basicConfig(format=logging_message_format)
 logging.getLogger(metadata.name).setLevel(100)
 
 
-def set_logging_level(lvl: int):
+def set_logging_level(lvl: int, propagate: bool=False) -> None:
     """Set logging level for all loggers in the current Python process.
 
     Args:
-        level (int): Logging level (e.g., logging.INFO, logging.DEBUG)
+        level (int): Logging level (e.g., logging.INFO, logging.DEBUG).  This
+            is a required argument
+
+        propagate (bool): Setting this value to True will also turn on
+            logging for httpx and httpcore.
     """
     logging.getLogger(metadata.name).setLevel(lvl)
-    logging.getLogger("httpx").setLevel(lvl)
-    logging.getLogger("httpcore").setLevel(lvl)
+
+    if propagate is True:
+        logging.getLogger("httpx").setLevel(lvl)
+        logging.getLogger("httpcore").setLevel(lvl)
+
+    logging.getLogger(metadata.name).log(logging.INFO, f"ipsdk version {metadata.version}")
+    logging.getLogger(metadata.name).log(logging.INFO, f"Logging level set to {lvl}")
+    logging.getLogger(metadata.name).log(logging.INFO, f"Logging propagation is {propagate}")

--- a/ipsdk/connection.py
+++ b/ipsdk/connection.py
@@ -6,14 +6,19 @@ import traceback
 
 import urllib.parse
 
+from typing import Union
+
 import httpx
 
 from . import logger
 from . import metadata
-from . import jsonutils
 
 
 class HTTPMethod:
+    """
+    The HTTPMethod class acts as an enum for specifying the HTTP method to use
+    when constructing requests
+    """
     GET = "GET"
     POST = "POST"
     DELETE = "DELETE"
@@ -23,7 +28,64 @@ class HTTPMethod:
 
 class ConnectionBase(object):
 
-    def __init__(self, host, port=0, base_path=None, use_tls=True, verify=True, user=None, password=None, client_id=None, client_secret=None, timeout=30):
+    def __init__(self,
+                 host: str,
+                 port: int=0,
+                 base_path: str=None,
+                 use_tls: bool=True,
+                 verify: bool=True,
+                 user: str=None,
+                 password: str=None,
+                 client_id: str=None,
+                 client_secret: str=None,
+                 timeout: int=30):
+        """
+        Base class for all connection classes
+
+        ConnectionBase is the base connection type that all connection classes
+        are derived from.  It provides a set of common proprties used by both
+        the sync and async connection types.
+
+        Args:
+            host (str): The hostname or IP address to connect to
+
+            port (int): The port value used when connecting to the API.  If
+                this value is 0, the actual port value will be auto determined
+                using the value of use_tls.  When use_tls is True, the port
+                value will be set to 443 and when use_tls is False, the port
+                value will be set to 80.  The default value for port is 0.
+
+            base_path (str): The base url that is prepended to requests.  This
+                value should not include the hostname or port value.  The
+                default value is None
+
+            use_tls (bool): Enable or disable TLS for this connection.  When
+                this value is set to True, TLS will be enabled on the
+                connection and when this value is set to False, TLS will be
+                disabled.  The default value is True
+
+            verify (bool): Enable or disable certificate verification.  When
+                this value is set to True, certificates from the server are
+                verified and when this value is set to False, certificate
+                verification is disabled.  The default value for is True
+
+            user (str): The username used to authenticate to the server.  The
+                default value is None
+
+            password (str): The password used to authenticate to the server.
+                The default value is None.
+
+            client_id (str): The client_id value to use when authenticating
+                to the server using OAuth.  The default value is None
+
+            client_secret (str): The client_secret value to use when
+                authenticating to the server using OAuth  The default value
+                is None
+
+            timeout (int): The request timeout for sending requests to the
+                server.
+        """
+
         self.user = user
         self.password = password
 
@@ -40,8 +102,10 @@ class ConnectionBase(object):
         )
         self.client.headers["User-Agent"] = f"ipsdk/{metadata.version}"
 
-    def _make_base_url(self, host: str, port: int=0,
-                       base_path: str=None, use_tls: bool=True) -> str:
+    def _make_base_url(self, host: str,
+                       port: int=0,
+                       base_path: str=None,
+                       use_tls: bool=True) -> str:
         """
         Join parts of the request to construct a valid URL
 
@@ -49,10 +113,22 @@ class ConnectionBase(object):
         individual parts together to cnstruct a full URL.
 
         Args:
-            host (str): The hostname or IP address of the API endpoint
-            port (int): The port used to connect to the API
-            use_tls (bool): Enable or disable TLS support
-            base_path (str): Base path to prepend when consructing the final URI
+            host (str): The hostname or IP address of the API endpoint.  This
+                argument is required.
+
+            port (int): The port used to connect to the API.  If the value of
+                port is 0, the port will be auto determined based on the value
+                of use_tls.  When use_tls is True, the value of port will be
+                443 and when use_tls is False, the value of port will be 80.
+                The default value is 0
+
+            use_tls (bool): Enable or disable TLS support.  When the value is
+                set to True, TLS will be enabled on the connection and when
+                this value is False, TLS will be disabled.  The default value
+                is True
+
+            base_path (str): Base path to prepend when consructing the final
+                URL.   The default value is None
 
         Returns:
             A string that represents the full URL
@@ -71,50 +147,95 @@ class ConnectionBase(object):
         return urllib.parse.urlunsplit((proto, host, base_path, None, None))
 
     def _build_request(self,
-        method: str,
-        url: str,
-        data: [str, bytes, dict, list]=None,
-        params: dict=None
-    ) -> httpx.Request:
+                       method: str,
+                       path: str,
+                       json: [str, bytes, dict, list]=None,
+                       params: dict=None) -> httpx.Request:
         """
         Create a new instance of httpx.Request
+
+        Args:
+            method (str): The HTTP method to invoke for this request.  This
+                is a required argument
+
+            path (str): The path to the resource.  This value is appended to
+                the base URL of the client to generate the full URI.  This
+                is a required argument.
+
+            params (dict): A dict object of key value pairs that will be used
+                to construct the URL query string.  The default value is
+                None
+
+            json (str, bytes, dict, list): The body to include in the request
+                as a JSON object.  If the value of json is list or dict, the
+                data will be converted to a JSON string.   When this argument
+                is set, the "Content-Type" and "Accept" headers will be set
+                to "application/json". The default value is None
+
+        Returns:
+            A `httpx.Request` object that can be used to send to the server
         """
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
+
+        headers = {}
+
+        # If the value of json is not None, automatically set the Content-Type
+        # and Accept headers to "application/json".  Technically, httpx will do
+        # this for us but setting it here to make it very explicit.
+        if json is not None:
+            logger.debug("automatically setting Content-Type and Accept headers due to json data")
+            headers.update({
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            })
 
         if self.token is not None:
+            logger.debug("adding Authorization header to request")
             headers["Authorization"] = f"Bearer {self.token}"
 
+        # The value for the keyword `json` is passed to the httpx build_request
+        # function.  If the value is of type list or dict, it will
+        # automatically be dumped to a string value and inserted into the body
+        # of the request.
         return self.client.build_request(
             method=method,
-            url=url,
-            data=data,
+            url=path,
             params=params,
             headers=headers,
+            json=json,
         )
 
     @abc.abstractmethod
-    def _init_client(self, base_url, verify):
+    def _init_client(self, base_url: str=None, verify: bool=True):
         """
         Abstract method that will initialize the client
+
+        Args:
+            base_url (str): The base URL used to prepend to every request. The
+                default value is None
+
+            verify (bool): Enable or disable certificate verification.  The
+                default value is True
+
+        Returns:
+            A valid httpx client object.
         """
         pass
 
 
 class Connection(ConnectionBase):
 
-    def _init_client(self, base_url, verify: bool=True) -> httpx.Client:
+    def _init_client(self, base_url: str=None, verify: bool=True) -> httpx.Client:
         """
         Initialize the httpx.Client instance
 
         The `httpx.Client` instance provides the conenction to the server
         for sending requests and receiving responses.   This method will
-        initialize the client and return it to the calling function.  This
-        method is called from `__init__` for the Connection instance
+        initialize the client and return it to the calling function.
 
         Args:
+            base_url (str): The base url to use when crafting requests.  This
+                value will be prepended to all requests
+
             verify (bool): Enable or disable the validation of certificates
                 when connecting to a server over TLS
 
@@ -131,9 +252,16 @@ class Connection(ConnectionBase):
 
     @abc.abstractmethod
     def authenticate(self):
+        """
+        Abstract method for implementing authentication
+        """
         pass
 
-    def send_request(self, method: HTTPMethod, url: str, params: dict=None, data: [str, bytes, dict, list]=None) -> httpx.Response:
+    def _send_request(self,
+                      method: HTTPMethod,
+                      path: str,
+                      params: dict=None,
+                      json: [str, bytes, dict, list]=None) -> httpx.Response:
         """
         Send will send the request to the API endpoint and return the response
 
@@ -143,25 +271,35 @@ class Connection(ConnectionBase):
         `application/json`.
 
         Args:
-            request (Request): A `Request` object used to construct the HTTP
-                API call
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
 
         Returns:
-            A `Response` object
+            A `httpx.Response` object
         """
-
         if self.authenticated is not True:
             self.authenticate()
             self.authenticated = True
 
-        if isinstance(data, (dict, list)):
-            data = jsonutils.dumps(data)
-
         request = self._build_request(
             method=method,
-            url=url,
-            data=data,
-            params=params
+            path=path,
+            params=params,
+            json=json,
         )
 
         try:
@@ -182,40 +320,148 @@ class Connection(ConnectionBase):
 
         return res
 
-    def get(self, path, params=None):
-        return self.send_request(HTTPMethod.GET, url=path, params=params)
+    def get(self, path: str, params: dict=None) -> httpx.Response:
+        """
+        Send a HTTP GET request to the server and return the response.
 
-    def delete(self, path, params=None):
-        return self.send_request(HTTPMethod.DELETE, url=path, params=params)
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
 
-    def post(self, path, data=None, params=None):
-        return self.send_request(HTTPMethod.POST, url=path, params=params, data=data)
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
 
-    def put(self, path, data=None, params=None):
-        return self.send_request(HTTPMethod.PUT, url=path, params=params, data=data)
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
 
-    def patch(self, path, data=None, params=None):
-        return self.send_request(HTTPMethod.PATCH, url=path, params=params, data=data)
+        Returns:
+            A `httpx.Response` object
+        """
+        return self._send_request(HTTPMethod.GET, path=path, params=params)
 
+    def delete(self, path: str, params: dict=None) -> httpx.Response:
+        """
+        Send a HTTP DELETE request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return self._send_request(HTTPMethod.DELETE, path=path, params=params)
+
+    def post(self, path: str, params: dict=None, json: Union[str, bytes, list, dict]=None) -> httpx.Response:
+        """
+        Send a HTTP POST request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return self._send_request(HTTPMethod.POST, path=path, params=params, json=json)
+
+    def put(self, path: str, params: dict=None, json: Union[str, bytes, list, dict]=None) -> httpx.Response:
+        """
+        Send a HTTP PUT request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return self._send_request(HTTPMethod.PUT, path=path, params=params, json=json)
+
+    def patch(self, path: str, params: dict=None, json: Union[str, bytes, list, dict]=None) -> httpx.Response:
+        """
+        Send a HTTP PATCH request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return self._send_request(HTTPMethod.PATCH, path=path, params=params, json=json)
 
 
 class AsyncConnection(ConnectionBase):
 
-    def _init_client(self, base_url, verify: bool=True) -> httpx.AsyncClient:
+    def _init_client(self, base_url: str=None, verify: bool=True) -> httpx.AsyncClient:
         """
-        Initialize the httpx.Client instance
+        Initialize the httpx.AsyncClient instance
 
-        The `httpx.Client` instance provides the conenction to the server
+        The `httpx.AsyncClient` instance provides the conenction to the server
         for sending requests and receiving responses.   This method will
-        initialize the client and return it to the calling function.  This
-        method is called from `__init__` for the Connection instance
+        initialize the client and return it to the calling function.
 
         Args:
+            base_url (str): The base URL used to prepend to every request
+
             verify (bool): Enable or disable the validation of certificates
                 when connecting to a server over TLS
 
         Returns:
-            An instance of `httpx.Client`
+            An instance of `httpx.AsyncClient`
         """
 
         logger.info(f"Creating new async client for {base_url}")
@@ -229,7 +475,11 @@ class AsyncConnection(ConnectionBase):
     async def authenticate(self):
         pass
 
-    async def send_request(self, method: HTTPMethod, url: str, params: dict=None, data: [str, bytes, dict, list]=None) -> httpx.Response:
+    async def _send_request(self,
+                            method: HTTPMethod,
+                            path: str,
+                            params: dict=None,
+                            json: [str, bytes, dict, list]=None) -> httpx.Response:
         """
         Send will send the request to the API endpoint and return the response
 
@@ -239,8 +489,22 @@ class AsyncConnection(ConnectionBase):
         `application/json`.
 
         Args:
-            request (Request): A `Request` object used to construct the HTTP
-                API call
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
 
         Returns:
             A `Response` object
@@ -249,14 +513,11 @@ class AsyncConnection(ConnectionBase):
             await self.authenticate()
             self.authenticated = True
 
-        if isinstance(data, (dict, list)):
-            data = jsonutils.dumps(data)
-
         request = self._build_request(
             method=method,
-            url=url,
-            data=data,
+            path=path,
             params=params,
+            json=json,
         )
 
         try:
@@ -277,17 +538,125 @@ class AsyncConnection(ConnectionBase):
 
         return res
 
-    async def get(self, path, params=None):
-        return await self.send_request(HTTPMethod.GET, url=path, params=params)
+    async def get(self, path: str, params: dict=None) -> httpx.Response:
+        """
+        Send a HTTP GET request to the server and return the response.
 
-    async def delete(self, path, params=None):
-        return await self.send_request(HTTPMethod.DELETE, url=path, params=params)
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
 
-    async def post(self, path, data=None, params=None):
-        return await self.send_request(HTTPMethod.POST, url=path, params=params, data=data)
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
 
-    async def put(self, path, data=None, params=None):
-        return await self.send_request(HTTPMethod.PUT, url=path, params=params, data=data)
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
 
-    async def patch(self, path, data=None, params=None):
-        return await self.send_request(HTTPMethod.PATCH, url=path, params=params, data=data)
+        Returns:
+            A `httpx.Response` object
+        """
+        return await self._send_request(HTTPMethod.GET, url=path, params=params)
+
+    async def delete(self, path: str, params: dict=None) -> httpx.Response:
+        """
+        Send a HTTP DELETE request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return await self._send_request(HTTPMethod.DELETE, url=path, params=params)
+
+    async def post(self, path: str, params: dict=None, json: Union[str, bytes, dict, list]=None) -> httpx.Response:
+        """
+        Send a HTTP POST request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return await self._send_request(HTTPMethod.POST, url=path, params=params, json=json)
+
+    async def put(self, path: str, params: dict=None, json: Union[str, bytes, dict, list]=None) -> httpx.Response:
+        """
+        Send a HTTP PUT request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return await self._send_request(HTTPMethod.PUT, url=path, params=params, json=json)
+
+    async def patch(self, path: str, params: dict=None, json: Union[str, bytes, dict, list]=None) -> httpx.Response:
+        """
+        Send a HTTP PATCH request to the server and return the response.
+
+        Args:
+            method (HTTPMethod): The HTTP method to call when sending this
+                request to the server.  This argument is required.
+
+            path (str): The URI path to use for this request.  This value
+                will be combined with the client's base_url to create the full
+                path to the resource.  This argument is required.
+
+            params (dict): The set of key value pairs as a dict object used
+                to construct the query string for the request.  The default
+                value of params is None
+
+            json: (str, bytes, dict, list): The JSON payload to include in
+                the request when sent to the server.  The value must either be
+                a string representation of a JSON object or a dict or list
+                object that can be converted to a valid JSON string.  The
+                default value for json is None
+
+        Returns:
+            A `httpx.Response` object
+        """
+        return await self._send_request(HTTPMethod.PATCH, url=path, params=params, json=json)


### PR DESCRIPTION
The send methods were confusing as to whether or not data needed to be converted to string.  This change clears up the ambiguity.  It also updates the docstrings for the connection module and adds more details to the README.