### PR TITLE
Remove automatic status check

### DIFF
--- a/ipsdk/connection.py
+++ b/ipsdk/connection.py
@@ -318,7 +318,6 @@ class Connection(ConnectionBase):
 
         try:
             res = self.client.send(request)
-            res.raise_for_status()
 
         except httpx.RequestError as exc:
             logger.debug(traceback.format_exc())
@@ -543,7 +542,6 @@ class AsyncConnection(ConnectionBase):
 
         try:
             res = await self.client.send(request)
-            res.raise_for_status()
 
         except httpx.RequestError as exc:
             logger.debug(traceback.format_exc())


### PR DESCRIPTION
Ths is a breaking change that will now remove the automatic status check from connections.  The status check would raise an error if the returned
status code was greather than 299.   This check has been removed so the
connection will always return a response.