### PR TITLE
Adds request and response wrappers

### DIFF
--- a/src/ipsdk/connection.py
+++ b/src/ipsdk/connection.py
@@ -6,7 +6,7 @@ import traceback
 
 import urllib.parse
 
-from typing import Union, Optional, Dict, Any
+from typing import Union, Dict, Any, Optional
 
 import httpx
 
@@ -15,7 +15,7 @@ from . import metadata
 from . import exceptions
 
 
-class HTTPMethod:
+class HTTPMethod(object):
     """
     The HTTPMethod class acts as an enum for specifying the HTTP method to use
     when constructing requests
@@ -25,6 +25,190 @@ class HTTPMethod:
     DELETE = "DELETE"
     PUT = "PUT"
     PATCH = "PATCH"
+
+
+class Request(object):
+    """
+    Wrapper class for HTTP requests that provides a clean interface for request data
+
+    The Request class encapsulates all the information needed to make an HTTP request,
+    including the method, path, parameters, headers, and body data. This provides a
+    consistent interface for working with requests across the SDK.
+
+    Args:
+        method (str): The HTTP method (GET, POST, PUT, DELETE, PATCH)
+        path (str): The URL path for the request
+        params (Dict[str, Any], optional): Query parameters for the request
+        headers (Dict[str, str], optional): HTTP headers for the request
+        json (Union[str, bytes, dict, list], optional): JSON data for the request body
+
+    Raises:
+        ValueError: If required parameters are missing or invalid
+    """
+
+    def __init__(self,
+                 method: str,
+                 path: str,
+                 params: Optional[Dict[str, Any]] = None,
+                 headers: Optional[Dict[str, str]] = None,
+                 json: Optional[Union[str, bytes, dict, list]] = None):
+        self.method = method
+        self.path = path
+        self.params = params or {}
+        self.headers = headers or {}
+        self.json = json
+
+    @property
+    def url(self) -> str:
+        """
+        Get the full URL for this request
+
+        Returns:
+            str: The complete URL including path and query parameters
+        """
+        return self.path
+
+    def __repr__(self) -> str:
+        """
+        String representation of the request
+
+        Returns:
+            str: A string representation of the request
+        """
+        return f"Request(method='{self.method}', path='{self.path}')"
+
+
+class Response(object):
+    """
+    Wrapper class for HTTP responses that provides enhanced functionality over httpx.Response
+
+    The Response class wraps an httpx.Response object and provides additional convenience
+    methods and properties for working with API responses. It maintains compatibility
+    with the underlying httpx.Response while adding SDK-specific functionality.
+
+    Args:
+        httpx_response (httpx.Response): The underlying httpx response object
+
+    Raises:
+        ValueError: If the httpx_response is None or invalid
+    """
+
+    def __init__(self, httpx_response: httpx.Response):
+        if httpx_response is None:
+            raise ValueError("httpx_response cannot be None")
+
+        self._response = httpx_response
+
+    @property
+    def status_code(self) -> int:
+        """
+        Get the HTTP status code
+
+        Returns:
+            int: The HTTP status code
+        """
+        return self._response.status_code
+
+    @property
+    def headers(self) -> httpx.Headers:
+        """
+        Get the response headers
+
+        Returns:
+            httpx.Headers: The response headers
+        """
+        return self._response.headers
+
+    @property
+    def content(self) -> bytes:
+        """
+        Get the raw response content as bytes
+
+        Returns:
+            bytes: The raw response content
+        """
+        return self._response.content
+
+    @property
+    def text(self) -> str:
+        """
+        Get the response content as text
+
+        Returns:
+            str: The response content decoded as text
+        """
+        return self._response.text
+
+    @property
+    def url(self) -> httpx.URL:
+        """
+        Get the request URL
+
+        Returns:
+            httpx.URL: The URL that was requested
+        """
+        return self._response.url
+
+    @property
+    def request(self) -> httpx.Request:
+        """
+        Get the original request object
+
+        Returns:
+            httpx.Request: The original request that generated this response
+        """
+        return self._response.request
+
+    def json(self) -> Dict[str, Any]:
+        """
+        Parse the response content as JSON
+
+        Returns:
+            Dict[str, Any]: The parsed JSON response
+
+        Raises:
+            ValueError: If the response content is not valid JSON
+        """
+        try:
+            return self._response.json()
+        except Exception as exc:
+            raise ValueError(f"Failed to parse response as JSON: {str(exc)}")
+
+    def raise_for_status(self) -> None:
+        """
+        Raise an exception if the response status indicates an error
+
+        Raises:
+            httpx.HTTPStatusError: If the response status code indicates an error
+        """
+        self._response.raise_for_status()
+
+    def is_success(self) -> bool:
+        """
+        Check if the response indicates success (2xx status code)
+
+        Returns:
+            bool: True if the status code is in the 2xx range, False otherwise
+        """
+        return 200 <= self.status_code < 300
+
+    def is_error(self) -> bool:
+        """
+        Check if the response indicates an error (4xx or 5xx status code)
+
+        Returns:
+            bool: True if the status code indicates an error, False otherwise
+        """
+        return self.status_code >= 400
+
+    def __repr__(self) -> str:
+        """
+        String representation of the response
+
+        Returns:
+            str: A string representation of the response
+        """
+        return f"Response(status_code={self.status_code}, url='{self.url}')"
 
 
 class ConnectionBase(object):
@@ -151,8 +335,8 @@ class ConnectionBase(object):
     def _build_request(self,
                        method: str,
                        path: str,
-                       json: Optional[Union[str, bytes, Dict[str, Any], list]]=None,
-                       params: Optional[Dict[str, Any]]=None) -> httpx.Request:
+                       json: Optional[Union[str, bytes, dict, list]]=None,
+                       params: Optional[dict]=None) -> httpx.Request:
         """
         Create a new instance of httpx.Request
 
@@ -208,7 +392,7 @@ class ConnectionBase(object):
 
     @abc.abstractmethod
     def _init_client(self,
-                     base_url: str | None = None,
+                     base_url: Optional[str] = None,
                      verify: bool = True,
                      timeout: int = 30):
         """
@@ -233,7 +417,7 @@ class ConnectionBase(object):
 class Connection(ConnectionBase):
 
     def _init_client(self,
-                     base_url: str | None = None,
+                     base_url: Optional[str] = None,
                      verify: bool = True,
                      timeout: int = 30) -> httpx.Client:
         """
@@ -260,7 +444,7 @@ class Connection(ConnectionBase):
         logger.info(f"Creating new client for {base_url}")
 
         return httpx.Client(
-            base_url=base_url,
+            base_url=base_url or "",
             verify=verify,
             timeout=timeout,
         )
@@ -275,8 +459,8 @@ class Connection(ConnectionBase):
     def _send_request(self,
                       method: str,
                       path: str,
-                      params: Optional[Dict[str, Any]]=None,
-                      json: Optional[Union[str, bytes, Dict[str, Any], list]]=None) -> httpx.Response:
+                      params: Optional[dict]=None,
+                      json: Optional[Union[str, bytes, dict, list]]=None) -> Response:
         """
         Send will send the request to the API endpoint and return the response
 
@@ -304,7 +488,7 @@ class Connection(ConnectionBase):
                 default value for json is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         if self.authenticated is not True:
             self.authenticate()
@@ -319,7 +503,7 @@ class Connection(ConnectionBase):
 
         try:
             res = self.client.send(request)
-            
+
             # Check for HTTP status errors
             if res.status_code >= 400:
                 logger.debug(f"HTTP {res.status_code} response from {request.url}")
@@ -342,7 +526,7 @@ class Connection(ConnectionBase):
         except exceptions.IpsdkError:
             # Re-raise our own exceptions
             raise
-            
+
         except Exception as exc:
             logger.debug(traceback.format_exc())
             raise exceptions.IpsdkError(
@@ -350,9 +534,9 @@ class Connection(ConnectionBase):
                 details={"request_url": str(request.url), "original_error": str(exc)}
             )
 
-        return res
+        return Response(res)
 
-    def get(self, path: str, params: Optional[Dict[str, Any]]=None) -> httpx.Response:
+    def get(self, path: str, params: Optional[dict]=None) -> Response:
         """
         Send a HTTP GET request to the server and return the response.
 
@@ -369,11 +553,11 @@ class Connection(ConnectionBase):
                 value of params is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return self._send_request(HTTPMethod.GET, path=path, params=params)
 
-    def delete(self, path: str, params: Optional[Dict[str, Any]]=None) -> httpx.Response:
+    def delete(self, path: str, params: Optional[dict]=None) -> Response:
         """
         Send a HTTP DELETE request to the server and return the response.
 
@@ -390,11 +574,11 @@ class Connection(ConnectionBase):
                 value of params is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return self._send_request(HTTPMethod.DELETE, path=path, params=params)
 
-    def post(self, path: str, params: Optional[Dict[str, Any]]=None, json: Optional[Union[str, bytes, list, Dict[str, Any]]]=None) -> httpx.Response:
+    def post(self, path: str, params: Optional[dict]=None, json: Optional[Union[str, bytes, list, dict]]=None) -> Response:
         """
         Send a HTTP POST request to the server and return the response.
 
@@ -417,11 +601,11 @@ class Connection(ConnectionBase):
                 default value for json is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return self._send_request(HTTPMethod.POST, path=path, params=params, json=json)
 
-    def put(self, path: str, params: Optional[Dict[str, Any]]=None, json: Optional[Union[str, bytes, list, Dict[str, Any]]]=None) -> httpx.Response:
+    def put(self, path: str, params: Optional[dict]=None, json: Optional[Union[str, bytes, list, dict]]=None) -> Response:
         """
         Send a HTTP PUT request to the server and return the response.
 
@@ -444,11 +628,11 @@ class Connection(ConnectionBase):
                 default value for json is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return self._send_request(HTTPMethod.PUT, path=path, params=params, json=json)
 
-    def patch(self, path: str, params: Optional[Dict[str, Any]]=None, json: Optional[Union[str, bytes, list, Dict[str, Any]]]=None) -> httpx.Response:
+    def patch(self, path: str, params: Optional[dict]=None, json: Optional[Union[str, bytes, list, dict]]=None) -> Response:
         """
         Send a HTTP PATCH request to the server and return the response.
 
@@ -471,7 +655,7 @@ class Connection(ConnectionBase):
                 default value for json is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return self._send_request(HTTPMethod.PATCH, path=path, params=params, json=json)
 
@@ -479,7 +663,7 @@ class Connection(ConnectionBase):
 class AsyncConnection(ConnectionBase):
 
     def _init_client(self,
-                     base_url: str | None = None,
+                     base_url: Optional[str] = None,
                      verify: bool = True,
                      timeout: int = 30) -> httpx.AsyncClient:
         """
@@ -505,7 +689,7 @@ class AsyncConnection(ConnectionBase):
         logger.info(f"Creating new async client for {base_url}")
 
         return httpx.AsyncClient(
-            base_url=base_url,
+            base_url=base_url or "",
             verify=verify,
             timeout=timeout
         )
@@ -517,8 +701,8 @@ class AsyncConnection(ConnectionBase):
     async def _send_request(self,
                             method: str,
                             path: str,
-                            params: Optional[Dict[str, Any]]=None,
-                            json: Optional[Union[str, bytes, Dict[str, Any], list]]=None) -> httpx.Response:
+                            params: Optional[dict]=None,
+                            json: Optional[Union[str, bytes, dict, list]]=None) -> Response:
         """
         Send will send the request to the API endpoint and return the response
 
@@ -561,7 +745,7 @@ class AsyncConnection(ConnectionBase):
 
         try:
             res = await self.client.send(request)
-            
+
             # Check for HTTP status errors
             if res.status_code >= 400:
                 logger.debug(f"HTTP {res.status_code} response from {request.url}")
@@ -584,7 +768,7 @@ class AsyncConnection(ConnectionBase):
         except exceptions.IpsdkError:
             # Re-raise our own exceptions
             raise
-            
+
         except Exception as exc:
             logger.debug(traceback.format_exc())
             raise exceptions.IpsdkError(
@@ -592,9 +776,9 @@ class AsyncConnection(ConnectionBase):
                 details={"request_url": str(request.url), "original_error": str(exc)}
             )
 
-        return res
+        return Response(res)
 
-    async def get(self, path: str, params: dict=None) -> httpx.Response:
+    async def get(self, path: str, params: Optional[dict]=None) -> Response:
         """
         Send a HTTP GET request to the server and return the response.
 
@@ -611,11 +795,11 @@ class AsyncConnection(ConnectionBase):
                 value of params is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return await self._send_request(HTTPMethod.GET, path=path, params=params)
 
-    async def delete(self, path: str, params: dict=None) -> httpx.Response:
+    async def delete(self, path: str, params: Optional[dict]=None) -> Response:
         """
         Send a HTTP DELETE request to the server and return the response.
 
@@ -632,11 +816,11 @@ class AsyncConnection(ConnectionBase):
                 value of params is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return await self._send_request(HTTPMethod.DELETE, path=path, params=params)
 
-    async def post(self, path: str, params: dict=None, json: Union[str, bytes, dict, list]=None) -> httpx.Response:
+    async def post(self, path: str, params: Optional[dict]=None, json: Optional[Union[str, bytes, dict, list]]=None) -> Response:
         """
         Send a HTTP POST request to the server and return the response.
 
@@ -659,11 +843,11 @@ class AsyncConnection(ConnectionBase):
                 default value for json is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return await self._send_request(HTTPMethod.POST, path=path, params=params, json=json)
 
-    async def put(self, path: str, params: dict=None, json: Union[str, bytes, dict, list]=None) -> httpx.Response:
+    async def put(self, path: str, params: Optional[dict]=None, json: Optional[Union[str, bytes, dict, list]]=None) -> Response:
         """
         Send a HTTP PUT request to the server and return the response.
 
@@ -686,11 +870,11 @@ class AsyncConnection(ConnectionBase):
                 default value for json is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return await self._send_request(HTTPMethod.PUT, path=path, params=params, json=json)
 
-    async def patch(self, path: str, params: dict=None, json: Union[str, bytes, dict, list]=None) -> httpx.Response:
+    async def patch(self, path: str, params: Optional[dict]=None, json: Optional[Union[str, bytes, dict, list]]=None) -> Response:
         """
         Send a HTTP PATCH request to the server and return the response.
 
@@ -713,6 +897,6 @@ class AsyncConnection(ConnectionBase):
                 default value for json is None
 
         Returns:
-            A `httpx.Response` object
+            A `Response` object
         """
         return await self._send_request(HTTPMethod.PATCH, path=path, params=params, json=json)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,1024 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+import pytest
+from unittest.mock import Mock, AsyncMock, patch
+
+import httpx
+
+from ipsdk.connection import (
+    HTTPMethod,
+    Request,
+    Response,
+    ConnectionBase,
+    Connection,
+    AsyncConnection
+)
+from ipsdk import exceptions
+
+
+# --------- Fixtures ---------
+
+@pytest.fixture
+def mock_httpx_response():
+    """Create a mock httpx.Response for testing."""
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.content = b'{"key": "value"}'
+    mock_response.text = '{"key": "value"}'
+    mock_response.url = httpx.URL("https://example.com/api/test")
+    mock_response.request = Mock()
+    mock_response.json.return_value = {"key": "value"}
+    return mock_response
+
+
+@pytest.fixture
+def connection_base_mock():
+    """Create a ConnectionBase instance with mocked dependencies."""
+    with patch.object(ConnectionBase, '_init_client') as mock_init:
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_init.return_value = mock_client
+        
+        conn = ConnectionBase("example.com")
+        yield conn
+
+
+@pytest.fixture
+def connection_mock():
+    """Create a Connection instance with mocked dependencies.""" 
+    with patch.object(ConnectionBase, '__init__', lambda self, *args, **kwargs: None):
+        conn = Connection("example.com")
+        conn.authenticated = False
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        yield conn
+
+
+@pytest.fixture
+def async_connection_mock():
+    """Create an AsyncConnection instance with mocked dependencies."""
+    with patch.object(ConnectionBase, '__init__', lambda self, *args, **kwargs: None):
+        conn = AsyncConnection("example.com")
+        conn.authenticated = False
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        conn.authenticate = AsyncMock()
+        yield conn
+
+
+# --------- HTTPMethod Tests ---------
+
+def test_http_method_constants():
+    """Test that HTTPMethod class has correct constants."""
+    assert HTTPMethod.GET == "GET"
+    assert HTTPMethod.POST == "POST"
+    assert HTTPMethod.DELETE == "DELETE"
+    assert HTTPMethod.PUT == "PUT"
+    assert HTTPMethod.PATCH == "PATCH"
+
+
+# --------- Request Class Tests ---------
+
+def test_request_creation():
+    """Test creating a basic Request object."""
+    req = Request("GET", "/api/test")
+    assert req.method == "GET"
+    assert req.path == "/api/test"
+    assert req.params == {}
+    assert req.headers == {}
+    assert req.json is None
+
+
+def test_request_with_all_params():
+    """Test creating a Request with all parameters."""
+    params = {"key": "value"}
+    headers = {"Authorization": "Bearer token"}
+    json_data = {"data": "test"}
+    
+    req = Request(
+        method="POST",
+        path="/api/create",
+        params=params,
+        headers=headers,
+        json=json_data
+    )
+    
+    assert req.method == "POST"
+    assert req.path == "/api/create"
+    assert req.params == params
+    assert req.headers == headers
+    assert req.json == json_data
+
+
+def test_request_url_property():
+    """Test Request url property."""
+    req = Request("GET", "/api/test")
+    assert req.url == "/api/test"
+
+
+def test_request_repr():
+    """Test Request string representation."""
+    req = Request("GET", "/api/test")
+    expected = "Request(method='GET', path='/api/test')"
+    assert repr(req) == expected
+
+
+def test_request_with_none_params():
+    """Test Request with None params and headers."""
+    req = Request("GET", "/api/test", params=None, headers=None)
+    assert req.params == {}
+    assert req.headers == {}
+
+
+def test_request_with_different_json_types():
+    """Test Request with different JSON data types."""
+    # Test with dict
+    req_dict = Request("POST", "/api/test", json={"key": "value"})
+    assert req_dict.json == {"key": "value"}
+    
+    # Test with list
+    req_list = Request("POST", "/api/test", json=[1, 2, 3])
+    assert req_list.json == [1, 2, 3]
+    
+    # Test with string
+    req_str = Request("POST", "/api/test", json='{"key": "value"}')
+    assert req_str.json == '{"key": "value"}'
+    
+    # Test with bytes
+    req_bytes = Request("POST", "/api/test", json=b'{"key": "value"}')
+    assert req_bytes.json == b'{"key": "value"}'
+
+
+def test_request_empty_path():
+    """Test Request with empty path."""
+    req = Request("GET", "")
+    assert req.path == ""
+    assert req.url == ""
+
+
+# --------- Response Class Tests ---------
+
+def test_response_creation(mock_httpx_response):
+    """Test creating a Response object."""
+    response = Response(mock_httpx_response)
+    assert response.status_code == 200
+    assert response.headers == {"Content-Type": "application/json"}
+    assert response.content == b'{"key": "value"}'
+    assert response.text == '{"key": "value"}'
+    assert response.url == httpx.URL("https://example.com/api/test")
+    assert response.request is not None
+
+
+def test_response_none_httpx_response():
+    """Test Response creation with None httpx_response raises ValueError."""
+    with pytest.raises(ValueError, match="httpx_response cannot be None"):
+        Response(None)
+
+
+def test_response_json_success(mock_httpx_response):
+    """Test Response json method returns parsed JSON."""
+    response = Response(mock_httpx_response)
+    result = response.json()
+    assert result == {"key": "value"}
+
+
+def test_response_json_failure():
+    """Test Response json method raises ValueError on parse error."""
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+    
+    response = Response(mock_response)
+    with pytest.raises(ValueError, match="Failed to parse response as JSON"):
+        response.json()
+
+
+def test_response_raise_for_status():
+    """Test Response raise_for_status delegates to httpx response."""
+    mock_response = Mock(spec=httpx.Response)
+    response = Response(mock_response)
+    
+    response.raise_for_status()
+    mock_response.raise_for_status.assert_called_once()
+
+
+def test_response_is_success():
+    """Test Response is_success method."""
+    mock_response = Mock(spec=httpx.Response)
+    
+    # Test successful status codes
+    for status in [200, 201, 204, 299]:
+        mock_response.status_code = status
+        response = Response(mock_response)
+        assert response.is_success() is True
+    
+    # Test non-successful status codes
+    for status in [199, 300, 400, 404, 500]:
+        mock_response.status_code = status
+        response = Response(mock_response)
+        assert response.is_success() is False
+
+
+def test_response_is_error():
+    """Test Response is_error method."""
+    mock_response = Mock(spec=httpx.Response)
+    
+    # Test error status codes
+    for status in [400, 401, 404, 500, 502]:
+        mock_response.status_code = status
+        response = Response(mock_response)
+        assert response.is_error() is True
+    
+    # Test non-error status codes
+    for status in [200, 201, 299, 300, 399]:
+        mock_response.status_code = status
+        response = Response(mock_response)
+        assert response.is_error() is False
+
+
+def test_response_repr():
+    """Test Response string representation."""
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.url = httpx.URL("https://example.com/api/test")
+    
+    response = Response(mock_response)
+    expected = "Response(status_code=200, url='https://example.com/api/test')"
+    assert repr(response) == expected
+
+
+def test_response_various_status_codes():
+    """Test Response with various HTTP status codes."""
+    status_codes = [100, 200, 201, 204, 301, 400, 401, 403, 404, 500, 502]
+    
+    for status_code in status_codes:
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = status_code
+        
+        response = Response(mock_response)
+        assert response.status_code == status_code
+        
+        # Test success/error classification
+        if 200 <= status_code < 300:
+            assert response.is_success() is True
+            assert response.is_error() is False
+        elif status_code >= 400:
+            assert response.is_error() is True
+            assert response.is_success() is False
+        else:
+            assert response.is_success() is False
+            assert response.is_error() is False
+
+
+def test_response_json_with_different_exceptions():
+    """Test Response json method with different exception types."""
+    mock_response = Mock(spec=httpx.Response)
+    
+    # Test with JSONDecodeError
+    mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+    response = Response(mock_response)
+    with pytest.raises(ValueError, match="Failed to parse response as JSON"):
+        response.json()
+    
+    # Test with generic exception
+    mock_response.json.side_effect = RuntimeError("Generic error")
+    response = Response(mock_response)
+    with pytest.raises(ValueError, match="Failed to parse response as JSON: Generic error"):
+        response.json()
+
+
+def test_response_properties_delegation():
+    """Test that Response properly delegates properties to httpx response."""
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 201
+    mock_response.headers = {"X-Custom": "value"}
+    mock_response.content = b"test content"
+    mock_response.text = "test content"
+    mock_response.url = httpx.URL("https://test.com")
+    mock_request = Mock()
+    mock_response.request = mock_request
+    
+    response = Response(mock_response)
+    
+    # Verify all properties are correctly delegated
+    assert response.status_code == 201
+    assert response.headers == {"X-Custom": "value"}
+    assert response.content == b"test content"
+    assert response.text == "test content"
+    assert response.url == httpx.URL("https://test.com")
+    assert response.request is mock_request
+
+
+# --------- ConnectionBase Tests ---------
+
+class TestConnectionBase:
+    """Test suite for ConnectionBase class."""
+    
+    def test_make_base_url_default_ports(self):
+        """Test _make_base_url with default ports."""
+        # Mock _init_client since ConnectionBase is abstract
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            
+            # Test HTTPS default port
+            url = conn._make_base_url("example.com", 0, None, True)
+            assert url == "https://example.com"
+            
+            # Test HTTP default port
+            url = conn._make_base_url("example.com", 0, None, False)
+            assert url == "http://example.com"
+    
+    def test_make_base_url_custom_ports(self):
+        """Test _make_base_url with custom ports."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            
+            # Test custom port for HTTPS
+            url = conn._make_base_url("example.com", 8443, None, True)
+            assert url == "https://example.com:8443"
+            
+            # Test custom port for HTTP
+            url = conn._make_base_url("example.com", 8080, None, False)
+            assert url == "http://example.com:8080"
+    
+    def test_make_base_url_with_base_path(self):
+        """Test _make_base_url with base path."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            
+            url = conn._make_base_url("example.com", 0, "/api/v1", True)
+            assert url == "https://example.com/api/v1"
+    
+    def test_make_base_url_standard_ports(self):
+        """Test _make_base_url with standard ports (80, 443)."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            
+            # Standard HTTPS port should not appear in URL
+            url = conn._make_base_url("example.com", 443, None, True)
+            assert url == "https://example.com"
+            
+            # Standard HTTP port should not appear in URL
+            url = conn._make_base_url("example.com", 80, None, False)
+            assert url == "http://example.com"
+    
+    def test_build_request_basic(self):
+        """Test _build_request with basic parameters."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            conn.client = Mock()
+            conn.token = None
+            
+            mock_request = Mock()
+            conn.client.build_request.return_value = mock_request
+            
+            request = conn._build_request("GET", "/api/test")
+            
+            conn.client.build_request.assert_called_once_with(
+                method="GET",
+                url="/api/test",
+                params=None,
+                headers={},
+                json=None
+            )
+            assert request == mock_request
+    
+    def test_build_request_with_json(self):
+        """Test _build_request with JSON data."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            conn.client = Mock()
+            conn.token = None
+            
+            mock_request = Mock()
+            conn.client.build_request.return_value = mock_request
+            
+            json_data = {"key": "value"}
+            conn._build_request("POST", "/api/create", json=json_data)
+            
+            expected_headers = {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+            conn.client.build_request.assert_called_once_with(
+                method="POST",
+                url="/api/create",
+                params=None,
+                headers=expected_headers,
+                json=json_data
+            )
+    
+    def test_build_request_with_token(self):
+        """Test _build_request with authentication token."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            conn.client = Mock()
+            conn.token = "test-token"
+            
+            mock_request = Mock()
+            conn.client.build_request.return_value = mock_request
+            
+            conn._build_request("GET", "/api/test")
+            
+            expected_headers = {
+                "Authorization": "Bearer test-token"
+            }
+            conn.client.build_request.assert_called_once_with(
+                method="GET",
+                url="/api/test",
+                params=None,
+                headers=expected_headers,
+                json=None
+            )
+    
+    def test_build_request_with_params(self):
+        """Test _build_request with query parameters."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            conn.client = Mock()
+            conn.token = None
+            
+            mock_request = Mock()
+            conn.client.build_request.return_value = mock_request
+            
+            params = {"key": "value", "limit": 10}
+            conn._build_request("GET", "/api/test", params=params)
+            
+            conn.client.build_request.assert_called_once_with(
+                method="GET",
+                url="/api/test",
+                params=params,
+                headers={},
+                json=None
+            )
+    
+    def test_initialization_with_all_params(self):
+        """Test ConnectionBase initialization with all parameters."""
+        with patch.object(ConnectionBase, '_init_client') as mock_init:
+            mock_client = Mock()
+            mock_client.headers = {}
+            mock_init.return_value = mock_client
+            
+            conn = ConnectionBase(
+                host="example.com",
+                port=8443,
+                base_path="/api/v1",
+                use_tls=True,
+                verify=True,
+                user="testuser",
+                password="testpass",
+                client_id="test_id",
+                client_secret="test_secret",
+                timeout=60
+            )
+            
+            assert conn.user == "testuser"
+            assert conn.password == "testpass"
+            assert conn.client_id == "test_id"
+            assert conn.client_secret == "test_secret"
+            assert conn.token is None
+            assert conn.authenticated is False
+            
+            mock_init.assert_called_once_with(
+                base_url="https://example.com:8443/api/v1",
+                verify=True,
+                timeout=60
+            )
+
+    def test_make_base_url_edge_cases(self):
+        """Test _make_base_url with edge cases."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            
+            # Test with IP address
+            url = conn._make_base_url("192.168.1.1", 0, None, True)
+            assert url == "https://192.168.1.1"
+            
+            # Test with localhost
+            url = conn._make_base_url("localhost", 3000, None, False)
+            assert url == "http://localhost:3000"
+            
+            # Test with empty base_path vs None
+            url = conn._make_base_url("example.com", 0, "", True)
+            assert url == "https://example.com"
+            
+            # Test with base_path starting with slash
+            url = conn._make_base_url("example.com", 0, "/api/v2", True)
+            assert url == "https://example.com/api/v2"
+            
+            # Test with base_path not starting with slash
+            url = conn._make_base_url("example.com", 0, "api/v2", True)
+            assert url == "https://example.com/api/v2"
+
+    def test_build_request_edge_cases(self):
+        """Test _build_request with edge cases."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = ConnectionBase("example.com")
+            conn.client = Mock()
+            conn.token = None
+            
+            mock_request = Mock()
+            conn.client.build_request.return_value = mock_request
+            
+            # Test with empty params dict
+            conn._build_request("GET", "/api/test", params={})
+            conn.client.build_request.assert_called_with(
+                method="GET",
+                url="/api/test",
+                params={},
+                headers={},
+                json=None
+            )
+            
+            # Test with empty headers dict
+            conn._build_request("GET", "/api/test", json=None)
+            
+            # Test with both token and json data
+            conn.token = "test-token"
+            json_data = {"test": "data"}
+            conn._build_request("POST", "/api/test", json=json_data)
+            
+            expected_headers = {
+                "Authorization": "Bearer test-token",
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+            conn.client.build_request.assert_called_with(
+                method="POST",
+                url="/api/test",
+                params=None,
+                headers=expected_headers,
+                json=json_data
+            )
+
+
+# --------- Connection Class Tests ---------
+
+class TestConnection:
+    """Test suite for Connection class."""
+    
+    def test_init_client(self):
+        """Test Connection _init_client method."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = Connection("example.com")
+        client = conn._init_client("https://example.com", True, 30)
+        assert isinstance(client, httpx.Client)
+    
+    @patch('ipsdk.connection.httpx.Client')
+    @patch.object(ConnectionBase, '__init__', lambda self, *args, **kwargs: None)
+    def test_init_client_with_params(self, mock_client_class):
+        """Test Connection _init_client with specific parameters."""
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        
+        conn = Connection("example.com")
+        result = conn._init_client("https://example.com/api", False, 60)
+        
+        mock_client_class.assert_called_once_with(
+            base_url="https://example.com/api",
+            verify=False,
+            timeout=60
+        )
+        assert result == mock_client
+    
+    def test_send_request_authentication(self):
+        """Test _send_request triggers authentication when needed."""
+        with patch.object(Connection, 'authenticate') as mock_auth:
+            conn = Connection("example.com")
+            conn.authenticated = False
+            conn.client = Mock()
+            
+            mock_response = Mock(spec=httpx.Response)
+            mock_response.status_code = 200
+            conn.client.send.return_value = mock_response
+            conn._build_request = Mock(return_value=Mock())
+            
+            result = conn._send_request("GET", "/api/test")
+            
+            mock_auth.assert_called_once()
+            assert conn.authenticated is True
+            assert isinstance(result, Response)
+    
+    def test_send_request_no_authentication_when_already_authenticated(self):
+        """Test _send_request skips authentication when already authenticated."""
+        with patch.object(Connection, 'authenticate') as mock_auth:
+            conn = Connection("example.com")
+            conn.authenticated = True
+            conn.client = Mock()
+            
+            mock_response = Mock(spec=httpx.Response)
+            mock_response.status_code = 200
+            conn.client.send.return_value = mock_response
+            conn._build_request = Mock(return_value=Mock())
+            
+            result = conn._send_request("GET", "/api/test")
+            
+            mock_auth.assert_not_called()
+            assert isinstance(result, Response)
+    
+    def test_send_request_httpx_request_error(self):
+        """Test _send_request handles httpx.RequestError."""
+        conn = Connection("example.com")
+        conn.authenticated = True
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        
+        mock_request = Mock()
+        mock_request.url = "https://example.com/api/test"
+        
+        exception = httpx.RequestError("Connection failed", request=mock_request)
+        conn.client.send.side_effect = exception
+        
+        with pytest.raises(exceptions.NetworkError):
+            conn._send_request("GET", "/api/test")
+    
+    def test_send_request_httpx_status_error(self):
+        """Test _send_request handles httpx.HTTPStatusError."""
+        conn = Connection("example.com")
+        conn.authenticated = True
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        
+        mock_request = Mock()
+        mock_request.url = "https://example.com/api/test"
+        mock_response = Mock()
+        mock_response.status_code = 500
+        
+        exception = httpx.HTTPStatusError("Server error", request=mock_request, response=mock_response)
+        conn.client.send.side_effect = exception
+        
+        with pytest.raises(exceptions.ServerError):
+            conn._send_request("GET", "/api/test")
+    
+    def test_send_request_generic_exception(self):
+        """Test _send_request handles generic exceptions."""
+        conn = Connection("example.com")
+        conn.authenticated = True
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        
+        conn.client.send.side_effect = RuntimeError("Generic error")
+        
+        with pytest.raises(exceptions.IpsdkError):
+            conn._send_request("GET", "/api/test")
+    
+    def test_get_method(self):
+        """Test Connection get method."""
+        conn = Connection("example.com")
+        conn._send_request = Mock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        result = conn.get("/api/test", params=params)
+        
+        conn._send_request.assert_called_once_with("GET", path="/api/test", params=params)
+        assert isinstance(result, Mock)
+    
+    def test_delete_method(self):
+        """Test Connection delete method."""
+        conn = Connection("example.com")
+        conn._send_request = Mock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        result = conn.delete("/api/test", params=params)
+        
+        conn._send_request.assert_called_once_with("DELETE", path="/api/test", params=params)
+        assert isinstance(result, Mock)
+    
+    def test_post_method(self):
+        """Test Connection post method."""
+        conn = Connection("example.com")
+        conn._send_request = Mock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        json_data = {"data": "test"}
+        result = conn.post("/api/create", params=params, json=json_data)
+        
+        conn._send_request.assert_called_once_with("POST", path="/api/create", params=params, json=json_data)
+        assert isinstance(result, Mock)
+    
+    def test_put_method(self):
+        """Test Connection put method."""
+        conn = Connection("example.com")
+        conn._send_request = Mock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        json_data = {"data": "test"}
+        result = conn.put("/api/update", params=params, json=json_data)
+        
+        conn._send_request.assert_called_once_with("PUT", path="/api/update", params=params, json=json_data)
+        assert isinstance(result, Mock)
+    
+    def test_patch_method(self):
+        """Test Connection patch method."""
+        conn = Connection("example.com")
+        conn._send_request = Mock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        json_data = {"data": "test"}
+        result = conn.patch("/api/patch", params=params, json=json_data)
+        
+        conn._send_request.assert_called_once_with("PATCH", path="/api/patch", params=params, json=json_data)
+        assert isinstance(result, Mock)
+
+    def test_http_methods_without_params(self):
+        """Test HTTP methods called without optional parameters."""
+        conn = Connection("example.com")
+        conn._send_request = Mock(return_value=Mock(spec=Response))
+        
+        # Test all methods without params
+        conn.get("/api/test")
+        conn._send_request.assert_called_with("GET", path="/api/test", params=None)
+        
+        conn.delete("/api/test")
+        conn._send_request.assert_called_with("DELETE", path="/api/test", params=None)
+        
+        conn.post("/api/test")
+        conn._send_request.assert_called_with("POST", path="/api/test", params=None, json=None)
+        
+        conn.put("/api/test")
+        conn._send_request.assert_called_with("PUT", path="/api/test", params=None, json=None)
+        
+        conn.patch("/api/test")
+        conn._send_request.assert_called_with("PATCH", path="/api/test", params=None, json=None)
+
+    def test_send_request_authentication_called_once(self):
+        """Test that authentication is only called once per connection."""
+        with patch.object(Connection, 'authenticate') as mock_auth:
+            conn = Connection("example.com")
+            conn.authenticated = False
+            conn.client = Mock()
+            
+            mock_response = Mock(spec=httpx.Response)
+            mock_response.status_code = 200
+            conn.client.send.return_value = mock_response
+            conn._build_request = Mock(return_value=Mock())
+            
+            # First request should trigger authentication
+            conn._send_request("GET", "/api/test1")
+            assert mock_auth.call_count == 1
+            assert conn.authenticated is True
+            
+            # Second request should not trigger authentication
+            conn._send_request("GET", "/api/test2")
+            assert mock_auth.call_count == 1  # Still 1, not called again
+
+    def test_init_client_with_none_base_url(self):
+        """Test Connection _init_client with None base_url."""
+        with patch.object(ConnectionBase, '__init__', lambda self, *args, **kwargs: None):
+            conn = Connection("example.com")
+            
+            with patch('ipsdk.connection.httpx.Client') as mock_client_class:
+                mock_client = Mock()
+                mock_client_class.return_value = mock_client
+                
+                result = conn._init_client(None, True, 30)
+                
+                mock_client_class.assert_called_once_with(
+                    base_url="",
+                    verify=True,
+                    timeout=30
+                )
+                assert result == mock_client
+
+
+# --------- AsyncConnection Class Tests ---------
+
+class TestAsyncConnection:
+    """Test suite for AsyncConnection class."""
+    
+    def test_init_client(self):
+        """Test AsyncConnection _init_client method."""
+        with patch.object(ConnectionBase, '_init_client'):
+            conn = AsyncConnection("example.com")
+        client = conn._init_client("https://example.com", True, 30)
+        assert isinstance(client, httpx.AsyncClient)
+    
+    @patch('ipsdk.connection.httpx.AsyncClient')
+    @patch.object(ConnectionBase, '__init__', lambda self, *args, **kwargs: None)
+    def test_init_client_with_params(self, mock_client_class):
+        """Test AsyncConnection _init_client with specific parameters."""
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        
+        conn = AsyncConnection("example.com")
+        result = conn._init_client("https://example.com/api", False, 60)
+        
+        mock_client_class.assert_called_once_with(
+            base_url="https://example.com/api",
+            verify=False,
+            timeout=60
+        )
+        assert result == mock_client
+    
+    @pytest.mark.asyncio
+    async def test_send_request_authentication(self):
+        """Test async _send_request triggers authentication when needed."""
+        conn = AsyncConnection("example.com")
+        conn.authenticated = False
+        conn.client = Mock()
+        
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        conn.client.send = AsyncMock(return_value=mock_response)
+        conn._build_request = Mock(return_value=Mock())
+        conn.authenticate = AsyncMock()
+        
+        result = await conn._send_request("GET", "/api/test")
+        
+        conn.authenticate.assert_called_once()
+        assert conn.authenticated is True
+        assert isinstance(result, Response)
+    
+    @pytest.mark.asyncio
+    async def test_send_request_no_authentication_when_already_authenticated(self):
+        """Test async _send_request skips authentication when already authenticated."""
+        conn = AsyncConnection("example.com")
+        conn.authenticated = True
+        conn.client = Mock()
+        
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        conn.client.send = AsyncMock(return_value=mock_response)
+        conn._build_request = Mock(return_value=Mock())
+        conn.authenticate = AsyncMock()
+        
+        result = await conn._send_request("GET", "/api/test")
+        
+        conn.authenticate.assert_not_called()
+        assert isinstance(result, Response)
+    
+    @pytest.mark.asyncio
+    async def test_send_request_httpx_request_error(self):
+        """Test async _send_request handles httpx.RequestError."""
+        conn = AsyncConnection("example.com")
+        conn.authenticated = True
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        
+        mock_request = Mock()
+        mock_request.url = "https://example.com/api/test"
+        
+        exception = httpx.RequestError("Connection failed", request=mock_request)
+        conn.client.send = AsyncMock(side_effect=exception)
+        
+        with pytest.raises(exceptions.NetworkError):
+            await conn._send_request("GET", "/api/test")
+    
+    @pytest.mark.asyncio
+    async def test_send_request_httpx_status_error(self):
+        """Test async _send_request handles httpx.HTTPStatusError."""
+        conn = AsyncConnection("example.com")
+        conn.authenticated = True
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        
+        mock_request = Mock()
+        mock_request.url = "https://example.com/api/test"
+        mock_response = Mock()
+        mock_response.status_code = 500
+        
+        exception = httpx.HTTPStatusError("Server error", request=mock_request, response=mock_response)
+        conn.client.send = AsyncMock(side_effect=exception)
+        
+        with pytest.raises(exceptions.ServerError):
+            await conn._send_request("GET", "/api/test")
+    
+    @pytest.mark.asyncio
+    async def test_send_request_generic_exception(self):
+        """Test async _send_request handles generic exceptions."""
+        conn = AsyncConnection("example.com")
+        conn.authenticated = True
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        
+        conn.client.send = AsyncMock(side_effect=RuntimeError("Generic error"))
+        
+        with pytest.raises(exceptions.IpsdkError):
+            await conn._send_request("GET", "/api/test")
+    
+    @pytest.mark.asyncio
+    async def test_get_method(self):
+        """Test AsyncConnection get method."""
+        conn = AsyncConnection("example.com")
+        conn._send_request = AsyncMock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        result = await conn.get("/api/test", params=params)
+        
+        conn._send_request.assert_called_once_with("GET", path="/api/test", params=params)
+        assert isinstance(result, Mock)
+    
+    @pytest.mark.asyncio
+    async def test_delete_method(self):
+        """Test AsyncConnection delete method."""
+        conn = AsyncConnection("example.com")
+        conn._send_request = AsyncMock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        result = await conn.delete("/api/test", params=params)
+        
+        conn._send_request.assert_called_once_with("DELETE", path="/api/test", params=params)
+        assert isinstance(result, Mock)
+    
+    @pytest.mark.asyncio
+    async def test_post_method(self):
+        """Test AsyncConnection post method."""
+        conn = AsyncConnection("example.com")
+        conn._send_request = AsyncMock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        json_data = {"data": "test"}
+        result = await conn.post("/api/create", params=params, json=json_data)
+        
+        conn._send_request.assert_called_once_with("POST", path="/api/create", params=params, json=json_data)
+        assert isinstance(result, Mock)
+    
+    @pytest.mark.asyncio
+    async def test_put_method(self):
+        """Test AsyncConnection put method."""
+        conn = AsyncConnection("example.com")
+        conn._send_request = AsyncMock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        json_data = {"data": "test"}
+        result = await conn.put("/api/update", params=params, json=json_data)
+        
+        conn._send_request.assert_called_once_with("PUT", path="/api/update", params=params, json=json_data)
+        assert isinstance(result, Mock)
+    
+    @pytest.mark.asyncio
+    async def test_patch_method(self):
+        """Test AsyncConnection patch method."""
+        conn = AsyncConnection("example.com")
+        conn._send_request = AsyncMock(return_value=Mock(spec=Response))
+        
+        params = {"key": "value"}
+        json_data = {"data": "test"}
+        result = await conn.patch("/api/patch", params=params, json=json_data)
+        
+        conn._send_request.assert_called_once_with("PATCH", path="/api/patch", params=params, json=json_data)
+        assert isinstance(result, Mock)
+
+    @pytest.mark.asyncio
+    async def test_async_http_methods_without_params(self):
+        """Test async HTTP methods called without optional parameters."""
+        conn = AsyncConnection("example.com")
+        conn._send_request = AsyncMock(return_value=Mock(spec=Response))
+        
+        # Test all methods without params
+        await conn.get("/api/test")
+        conn._send_request.assert_called_with("GET", path="/api/test", params=None)
+        
+        await conn.delete("/api/test")
+        conn._send_request.assert_called_with("DELETE", path="/api/test", params=None)
+        
+        await conn.post("/api/test")
+        conn._send_request.assert_called_with("POST", path="/api/test", params=None, json=None)
+        
+        await conn.put("/api/test")
+        conn._send_request.assert_called_with("PUT", path="/api/test", params=None, json=None)
+        
+        await conn.patch("/api/test")
+        conn._send_request.assert_called_with("PATCH", path="/api/test", params=None, json=None)
+
+    @pytest.mark.asyncio
+    async def test_async_send_request_authentication_called_once(self):
+        """Test that async authentication is only called once per connection."""
+        conn = AsyncConnection("example.com")
+        conn.authenticated = False
+        conn.client = Mock()
+        conn._build_request = Mock(return_value=Mock())
+        conn.authenticate = AsyncMock()
+        
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        conn.client.send = AsyncMock(return_value=mock_response)
+        
+        # First request should trigger authentication
+        await conn._send_request("GET", "/api/test1")
+        assert conn.authenticate.call_count == 1
+        assert conn.authenticated is True
+        
+        # Second request should not trigger authentication
+        await conn._send_request("GET", "/api/test2")
+        assert conn.authenticate.call_count == 1  # Still 1, not called again
+
+    def test_async_init_client_with_none_base_url(self):
+        """Test AsyncConnection _init_client with None base_url."""
+        with patch.object(ConnectionBase, '__init__', lambda self, *args, **kwargs: None):
+            conn = AsyncConnection("example.com")
+            
+            with patch('ipsdk.connection.httpx.AsyncClient') as mock_client_class:
+                mock_client = Mock()
+                mock_client_class.return_value = mock_client
+                
+                result = conn._init_client(None, True, 30)
+                
+                mock_client_class.assert_called_once_with(
+                    base_url="",
+                    verify=True,
+                    timeout=30
+                )
+                assert result == mock_client


### PR DESCRIPTION
This updates the connection to use request and response objects instead
of raw data.   This will make it easier going forward when integrating
`ipsdk` into other applications.