### PR TITLE
Wrap the logger stdlib levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,48 +158,28 @@ $ make premerge
 ## Logging
 
 By default all logging is turned off for `ipsdk`. To enable logging to
-`stdout`, use the `set_logging_level` function.
+`stdout`, use the `ipsdk.logger.set_level` function.
+
+The SDK provides logging level constants that you can use instead of importing the standard library logging module:
 
 ```python
 >>> import ipsdk
->>> import logging
 
->>> ipsdk.set_logging_level(logging.DEBUG)
-
->>> gateway = ipsdk.gateway_factory(host="gateway.itential.dev")
-2025-05-04 08:09:58,105: INFO: Creating new client for https://gateway.itential.dev/api/v2.0
-
->>> res = gateway.get("/devices")
-2025-05-04 08:10:12,009: DEBUG: connect_tcp.started host='gateway.itential.dev' port=443 local_address=None timeout=5.0 socket_options=None
-2025-05-04 08:10:12,076: DEBUG: connect_tcp.complete return_value=<httpcore._backends.sync.SyncStream object at 0x7fcb6cdcc980>
-2025-05-04 08:10:12,076: DEBUG: start_tls.started ssl_context=<ssl.SSLContext object at 0x7fcb6cf22a80> server_hostname='gateway.itential.dev' timeout=5.0
-2025-05-04 08:10:12,097: DEBUG: start_tls.complete return_value=<httpcore._backends.sync.SyncStream object at 0x7fcb6cdd4910>
-2025-05-04 08:10:12,097: DEBUG: send_request_headers.started request=<Request [b'POST']>
-2025-05-04 08:10:12,098: DEBUG: send_request_headers.complete
-2025-05-04 08:10:12,098: DEBUG: send_request_body.started request=<Request [b'POST']>
-2025-05-04 08:10:12,098: DEBUG: send_request_body.complete
-2025-05-04 08:10:12,098: DEBUG: receive_response_headers.started request=<Request [b'POST']>
-2025-05-04 08:10:12,231: DEBUG: receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Date', b'Sun, 04 May 2025 12:10:12 GMT'), (b'Content-Type', b'application/json'), (b'Transfer-Encoding', b'chunked'), (b'Connection', b'keep-alive'), (b'Server', b'cloudflare'), (b'Last-Modified', b'2025-05-04 12:10:12.220779'), (b'Cache-Control', b'no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0'), (b'Pragma', b'no-cache'), (b'Expires', b'-1'), (b'X-Frame-Options', b'DENY'), (b'X-Xss-Protection', b'1'), (b'X-Content-Type-Options', b'nosniff'), (b'Cf-Cache-Status', b'DYNAMIC'), (b'Content-Encoding', b'gzip'), (b'Set-Cookie', b'AutomationGatewayToken=NzQ3NS42MzM2NTcxMzYyNDg=; HttpOnly; Path=/'), (b'CF-RAY', b'93a7e4c1a9626abf-RDU'), (b'alt-svc', b'h3=":443"; ma=86400')])
-2025-05-04 08:10:12,232: INFO: HTTP Request: POST https://gateway.itential.dev/api/v2.0/login "HTTP/1.1 200 OK"
-2025-05-04 08:10:12,233: DEBUG: receive_response_body.started request=<Request [b'POST']>
-2025-05-04 08:10:12,233: DEBUG: receive_response_body.complete
-2025-05-04 08:10:12,233: DEBUG: response_closed.started
-2025-05-04 08:10:12,233: DEBUG: response_closed.complete
-2025-05-04 08:10:12,235: DEBUG: send_request_headers.started request=<Request [b'GET']>
-2025-05-04 08:10:12,235: DEBUG: send_request_headers.complete
-2025-05-04 08:10:12,235: DEBUG: send_request_body.started request=<Request [b'GET']>
-2025-05-04 08:10:12,235: DEBUG: send_request_body.complete
-2025-05-04 08:10:12,236: DEBUG: receive_response_headers.started request=<Request [b'GET']>
-2025-05-04 08:10:12,264: DEBUG: receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Date', b'Sun, 04 May 2025 12:10:12 GMT'), (b'Content-Type', b'application/json'), (b'Transfer-Encoding', b'chunked'), (b'Connection', b'keep-alive'), (b'Server', b'cloudflare'), (b'Last-Modified', b'2025-05-04 12:10:12.253899'), (b'Cache-Control', b'no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0'), (b'Pragma', b'no-cache'), (b'Expires', b'-1'), (b'X-Frame-Options', b'DENY'), (b'X-Xss-Protection', b'1'), (b'X-Content-Type-Options', b'nosniff'), (b'Cf-Cache-Status', b'DYNAMIC'), (b'Content-Encoding', b'gzip'), (b'CF-RAY', b'93a7e4c279e36abf-RDU'), (b'alt-svc', b'h3=":443"; ma=86400')])
-2025-05-04 08:10:12,264: INFO: HTTP Request: GET https://gateway.itential.dev/api/v2.0/devices "HTTP/1.1 200 OK"
-2025-05-04 08:10:12,264: DEBUG: receive_response_body.started request=<Request [b'GET']>
-2025-05-04 08:10:12,264: DEBUG: receive_response_body.complete
-2025-05-04 08:10:12,264: DEBUG: response_closed.started
-2025-05-04 08:10:12,265: DEBUG: response_closed.complete
-
->>> print(res)
-<Response [200 OK]>
+# Using ipsdk logging constants (recommended)
+>>> ipsdk.logger.set_level(ipsdk.logger.DEBUG)
 ```
+
+### Available Logging Levels
+
+The SDK provides the following logging level constants:
+
+- `ipsdk.logger.NOTSET` - No logging threshold (0)
+- `ipsdk.logger.DEBUG` - Debug messages (10)
+- `ipsdk.logger.INFO` - Informational messages (20)
+- `ipsdk.logger.WARNING` - Warning messages (30)
+- `ipsdk.logger.ERROR` - Error messages (40)
+- `ipsdk.logger.CRITICAL` - Critical error messages (50)
+- `ipsdk.logger.FATAL` - Fatal error messages (90)
 
 ## License
 

--- a/src/ipsdk/__init__.py
+++ b/src/ipsdk/__init__.py
@@ -3,10 +3,10 @@
 
 from . import metadata
 
+from . import logger
 from .platform import platform_factory
 from .gateway import gateway_factory
-from .logger import set_logging_level
 
 __version__ = metadata.version
 
-__all__ = ("platform_factory", "gateway_factory", "set_logging_level")
+__all__ = ("platform_factory", "gateway_factory", "logger")

--- a/src/ipsdk/logger.py
+++ b/src/ipsdk/logger.py
@@ -17,6 +17,15 @@ logging.getLogger(metadata.name).setLevel(100)
 logging.addLevelName(90, "FATAL")
 setattr(logging, "FATAL", 90)
 
+# Logging level constants that wrap stdlib logging module constants
+NOTSET = logging.NOTSET
+DEBUG = logging.DEBUG
+INFO = logging.INFO
+WARNING = logging.WARNING
+ERROR = logging.ERROR
+CRITICAL = logging.CRITICAL
+FATAL = logging.FATAL
+
 # Set the default logging level to 100
 logging.getLogger(metadata.name).setLevel(100)
 
@@ -77,7 +86,7 @@ def fatal(msg: str) -> None:
     sys.exit(1)
 
 
-def set_logging_level(lvl: int, propagate: bool=False) -> None:
+def set_level(lvl: int, propagate: bool=False) -> None:
     """Set logging level for all loggers in the current Python process.
 
     Args:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -145,15 +145,15 @@ class TestFatalFunction:
             mock_exit.assert_called_once_with(1)
 
 
-class TestSetLoggingLevel:
-    """Test the set_logging_level function."""
+class TestSetLevel:
+    """Test the set_level function."""
 
-    def test_set_logging_level_basic(self):
-        """Test set_logging_level sets the logger level correctly."""
+    def test_set_level_basic(self):
+        """Test set_level sets the logger level correctly."""
         with patch.object(logging.getLogger(metadata.name), 'setLevel') as mock_setLevel, \
              patch.object(logging.getLogger(metadata.name), 'log') as mock_log:
             
-            logger.set_logging_level(logging.DEBUG)
+            logger.set_level(logging.DEBUG)
             
             mock_setLevel.assert_called_once_with(logging.DEBUG)
             
@@ -162,27 +162,27 @@ class TestSetLoggingLevel:
             mock_log.assert_any_call(logging.INFO, f"Logging level set to {logging.DEBUG}")
             mock_log.assert_any_call(logging.INFO, "Logging propagation is False")
 
-    def test_set_logging_level_with_propagate_false(self):
-        """Test set_logging_level with propagate=False (default)."""
+    def test_set_level_with_propagate_false(self):
+        """Test set_level with propagate=False (default)."""
         with patch.object(logging.getLogger(metadata.name), 'setLevel') as mock_ipsdk_setLevel, \
              patch.object(logging.getLogger("httpx"), 'setLevel') as mock_httpx_setLevel, \
              patch.object(logging.getLogger("httpcore"), 'setLevel') as mock_httpcore_setLevel, \
              patch.object(logging.getLogger(metadata.name), 'log'):
             
-            logger.set_logging_level(logging.INFO, propagate=False)
+            logger.set_level(logging.INFO, propagate=False)
             
             mock_ipsdk_setLevel.assert_called_once_with(logging.INFO)
             mock_httpx_setLevel.assert_not_called()
             mock_httpcore_setLevel.assert_not_called()
 
-    def test_set_logging_level_with_propagate_true(self):
-        """Test set_logging_level with propagate=True."""
+    def test_set_level_with_propagate_true(self):
+        """Test set_level with propagate=True."""
         with patch.object(logging.getLogger(metadata.name), 'setLevel') as mock_ipsdk_setLevel, \
              patch.object(logging.getLogger("httpx"), 'setLevel') as mock_httpx_setLevel, \
              patch.object(logging.getLogger("httpcore"), 'setLevel') as mock_httpcore_setLevel, \
              patch.object(logging.getLogger(metadata.name), 'log') as mock_log:
             
-            logger.set_logging_level(logging.WARNING, propagate=True)
+            logger.set_level(logging.WARNING, propagate=True)
             
             mock_ipsdk_setLevel.assert_called_once_with(logging.WARNING)
             mock_httpx_setLevel.assert_called_once_with(logging.WARNING)
@@ -193,8 +193,8 @@ class TestSetLoggingLevel:
             mock_log.assert_any_call(logging.INFO, f"Logging level set to {logging.WARNING}")
             mock_log.assert_any_call(logging.INFO, "Logging propagation is True")
 
-    def test_set_logging_level_different_levels(self):
-        """Test set_logging_level with different logging levels."""
+    def test_set_level_different_levels(self):
+        """Test set_level with different logging levels."""
         test_levels = [
             logging.DEBUG,
             logging.INFO,
@@ -208,7 +208,7 @@ class TestSetLoggingLevel:
             with patch.object(logging.getLogger(metadata.name), 'setLevel') as mock_setLevel, \
                  patch.object(logging.getLogger(metadata.name), 'log') as mock_log:
                 
-                logger.set_logging_level(level)
+                logger.set_level(level)
                 
                 mock_setLevel.assert_called_once_with(level)
                 
@@ -273,14 +273,14 @@ class TestErrorConditions:
             logger.exception(test_exception)
             mock_log.assert_called_once_with(logging.ERROR, "")
 
-    def test_set_logging_level_with_custom_level(self):
-        """Test set_logging_level with custom numeric level."""
+    def test_set_level_with_custom_level(self):
+        """Test set_level with custom numeric level."""
         custom_level = 25  # Between INFO (20) and WARNING (30)
         
         with patch.object(logging.getLogger(metadata.name), 'setLevel') as mock_setLevel, \
              patch.object(logging.getLogger(metadata.name), 'log') as mock_log:
             
-            logger.set_logging_level(custom_level)
+            logger.set_level(custom_level)
             
             mock_setLevel.assert_called_once_with(custom_level)
             


### PR DESCRIPTION
This wraps the Python logging library levels so all levels are now ipsdk
levels.   This makes it easier in the future to create logging
enhancements if needed.