### PR TITLE
Fixes typos in all docstrings

### DIFF
--- a/src/ipsdk/connection.py
+++ b/src/ipsdk/connection.py
@@ -229,7 +229,7 @@ class ConnectionBase(object):
         Base class for all connection classes
 
         ConnectionBase is the base connection type that all connection classes
-        are derived from.  It provides a set of common proprties used by both
+        are derived from.  It provides a set of common properties used by both
         the sync and async connection types.
 
         Args:
@@ -297,7 +297,7 @@ class ConnectionBase(object):
         Join parts of the request to construct a valid URL
 
         This function will take the request object and join the
-        individual parts together to cnstruct a full URL.
+        individual parts together to construct a full URL.
 
         Args:
             host (str): The hostname or IP address of the API endpoint.  This
@@ -314,7 +314,7 @@ class ConnectionBase(object):
                 this value is False, TLS will be disabled.  The default value
                 is True
 
-            base_path (str): Base path to prepend when consructing the final
+            base_path (str): Base path to prepend when constructing the final
                 URL.   The default value is None
 
         Returns:
@@ -425,7 +425,7 @@ class Connection(ConnectionBase):
         """
         Initialize the httpx.Client instance
 
-        The `httpx.Client` instance provides the conenction to the server
+        The `httpx.Client` instance provides the connection to the server
         for sending requests and receiving responses.   This method will
         initialize the client and return it to the calling function.
 
@@ -672,7 +672,7 @@ class AsyncConnection(ConnectionBase):
         """
         Initialize the httpx.AsyncClient instance
 
-        The `httpx.AsyncClient` instance provides the conenction to the server
+        The `httpx.AsyncClient` instance provides the connection to the server
         for sending requests and receiving responses.   This method will
         initialize the client and return it to the calling function.
 

--- a/src/ipsdk/gateway.py
+++ b/src/ipsdk/gateway.py
@@ -177,7 +177,7 @@ def gateway_factory(
 
     Args:
         host (str): The target host for the connection. The default value for host
-            is `admin@itential`
+            is `localhost`
 
         port (int): Port number to use when connecting to the server.  The default
             value for port is `0`.  When the port value is set to 0, it will be

--- a/src/ipsdk/logger.py
+++ b/src/ipsdk/logger.py
@@ -34,7 +34,7 @@ def log(lvl: int, msg: str) -> None:
     """Send the log message with the specified level
 
     This function will send the log message to the logger with the specified
-    logging level.  This function should not be direclty invoked.  Use one
+    logging level.  This function should not be directly invoked.  Use one
     of the partials to send a log message with a given level.
 
     Args:

--- a/src/ipsdk/platform.py
+++ b/src/ipsdk/platform.py
@@ -42,9 +42,9 @@ def _make_basicauth_path() -> str:
 
 class AuthMixin(object):
     """
-    Authoriztion mixin for authenticating to Itential Platform.
+    Authorization mixin for authenticating to Itential Platform.
     """
-    
+
     # Attributes that should be provided by ConnectionBase
     user: Optional[str]
     password: Optional[str]
@@ -124,14 +124,14 @@ class AuthMixin(object):
         try:
             res = self.client.post(path, headers=headers, data=data)
             res.raise_for_status()
-            
+
             # Parse the response to extract the token
             response_data = jsonutils.loads(res.text)
             if isinstance(response_data, dict):
                 access_token = response_data.get("access_token")
             else:
                 access_token = None
-            
+
             if not access_token:
                 if isinstance(response_data, dict):
                     raise exceptions.TokenError(
@@ -145,9 +145,9 @@ class AuthMixin(object):
                         auth_type="oauth",
                         details={"response_type": str(type(response_data))}
                     )
-            
+
             self.token = access_token
-            
+
         except httpx.HTTPStatusError as exc:
             logger.error(traceback.format_exc())
             if exc.response.status_code in (401, 403):
@@ -191,7 +191,7 @@ class AsyncAuthMixin(object):
     """
     Platform is a HTTP connection to Itential Platform
     """
-    
+
     # Attributes that should be provided by ConnectionBase
     user: Optional[str]
     password: Optional[str]
@@ -271,14 +271,14 @@ class AsyncAuthMixin(object):
         try:
             res = await self.client.post(path, headers=headers, data=data)
             res.raise_for_status()
-            
+
             # Parse the response to extract the token
             response_data = jsonutils.loads(res.text)
             if isinstance(response_data, dict):
                 access_token = response_data.get("access_token")
             else:
                 access_token = None
-            
+
             if not access_token:
                 if isinstance(response_data, dict):
                     raise exceptions.TokenError(
@@ -292,9 +292,9 @@ class AsyncAuthMixin(object):
                         auth_type="oauth",
                         details={"response_type": str(type(response_data))}
                     )
-            
+
             self.token = access_token
-            
+
         except httpx.HTTPStatusError as exc:
             logger.error(traceback.format_exc())
             if exc.response.status_code in (401, 403):
@@ -364,7 +364,7 @@ def platform_factory(
 
     Args:
         host (str): The target host for the connection.  The default value for
-            host is `loclahost`
+            host is `localhost`
 
         port (int): Port number to connect to.   The default value for port
             is `0`.   When the value is set to `0`, the port will be automatically
@@ -379,10 +379,10 @@ def platform_factory(
             certificates and when this value is set to `False` Certificate
             verification will be disabled.  The default value is `True`
 
-        user (str): The username to ues when authenticating to the server.  The
+        user (str): The username to use when authenticating to the server.  The
             default value is `admin`
 
-        password (str): The password to use when authenticaing to the server.  The
+        password (str): The password to use when authenticating to the server.  The
             default value is `admin`
 
         client_id (str): Optional client ID for token-based authentication.  When


### PR DESCRIPTION
This update reviews all docstrings in the app and fixes all found typos in the docstrings.  No additional changes have been made.

Fixes #38