### PR TITLE
Add GitHub Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# GitHub Dependabot configuration for automated dependency updates
+# See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "itential/platform-team"
+    assignees:
+      - "itential/platform-team"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependabot"
+    # Group minor and patch updates together
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "itential/platform-team"
+    assignees:
+      - "itential/platform-team"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependabot"


### PR DESCRIPTION
Configures automated dependency updates for Python packages and GitHub Actions with weekly schedules, grouped updates, and proper team assignments for maintenance workflow.