### PR TITLE
refactor: Update ruff configuration and apply import formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,7 @@ ignore = [
     # Allow catching broad exceptions (necessary for HTTP client)
     "BLE001",
     # Allow raise without from inside except
-    "TRY200",
+    "B904",
     # Allow too many return statements
     "PLR0911",
     # Allow too many arguments
@@ -283,6 +283,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [tool.ruff.lint.isort]
 known-first-party = ["ipsdk"]
 force-single-line = true
+lines-between-types = 1
 
 [tool.ruff.lint.pylint]
 max-args = 8

--- a/src/ipsdk/connection.py
+++ b/src/ipsdk/connection.py
@@ -3,6 +3,7 @@
 
 import abc
 import urllib.parse
+
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -18,7 +19,6 @@ from .http import Response
 
 
 class ConnectionBase:
-
     client: Union[httpx.Client, httpx.AsyncClient]
 
     def __init__(
@@ -186,9 +186,7 @@ class ConnectionBase:
         # and Accept headers to "application/json".  Technically, httpx will do
         # this for us but setting it here to make it very explicit.
         if json is not None:
-            logging.debug(
-                "Setting Content-Type and Accept headers due to json data"
-            )
+            logging.debug("Setting Content-Type and Accept headers due to json data")
             headers.update(
                 {
                     "Content-Type": "application/json",
@@ -219,8 +217,7 @@ class ConnectionBase:
         params: Optional[Dict[str, Any]] = None,
         json: Optional[Union[str, bytes, dict, list]] = None,
     ) -> None:
-        """
-        """
+        """ """
         if not isinstance(method, HTTPMethod):
             msg = "method must be of type `HTTPMethod`"
             raise exceptions.IpsdkError(msg)
@@ -239,10 +236,7 @@ class ConnectionBase:
 
     @abc.abstractmethod
     def __init_client__(
-        self,
-        base_url: Optional[str] = None,
-        verify: bool = True,
-        timeout: int = 30
+        self, base_url: Optional[str] = None, verify: bool = True, timeout: int = 30
     ) -> Union[httpx.Client, httpx.AsyncClient]:
         """
         Abstract method that will initialize the client
@@ -263,14 +257,10 @@ class ConnectionBase:
 
 
 class Connection(ConnectionBase):
-
     client: httpx.Client  # Override the Union type from base class
 
     def __init_client__(
-        self,
-        base_url: Optional[str] = None,
-        verify: bool = True,
-        timeout: int = 30
+        self, base_url: Optional[str] = None, verify: bool = True, timeout: int = 30
     ) -> httpx.Client:
         """
         Initialize the httpx.Client instance
@@ -449,9 +439,7 @@ class Connection(ConnectionBase):
             A `Response` object
         """
         logging.trace(self.post)
-        return self._send_request(
-            HTTPMethod.POST, path=path, params=params, json=json
-        )
+        return self._send_request(HTTPMethod.POST, path=path, params=params, json=json)
 
     def put(
         self,
@@ -484,9 +472,7 @@ class Connection(ConnectionBase):
             A `Response` object
         """
         logging.trace(self.put)
-        return self._send_request(
-            HTTPMethod.PUT, path=path, params=params, json=json
-        )
+        return self._send_request(HTTPMethod.PUT, path=path, params=params, json=json)
 
     def patch(
         self,
@@ -519,20 +505,14 @@ class Connection(ConnectionBase):
             A `Response` object
         """
         logging.trace(self.patch)
-        return self._send_request(
-            HTTPMethod.PATCH, path=path, params=params, json=json
-        )
+        return self._send_request(HTTPMethod.PATCH, path=path, params=params, json=json)
 
 
 class AsyncConnection(ConnectionBase):
-
     client: httpx.AsyncClient  # Override the Union type from base class
 
     def __init_client__(
-        self,
-        base_url: Optional[str] = None,
-        verify: bool = True,
-        timeout: int = 30
+        self, base_url: Optional[str] = None, verify: bool = True, timeout: int = 30
     ) -> httpx.AsyncClient:
         """
         Initialize the httpx.AsyncClient instance
@@ -675,9 +655,7 @@ class AsyncConnection(ConnectionBase):
             A `Response` object
         """
         logging.trace(self.delete)
-        return await self._send_request(
-            HTTPMethod.DELETE, path=path, params=params
-        )
+        return await self._send_request(HTTPMethod.DELETE, path=path, params=params)
 
     async def post(
         self,

--- a/src/ipsdk/exceptions.py
+++ b/src/ipsdk/exceptions.py
@@ -91,11 +91,7 @@ class IpsdkError(Exception):
         details (dict): Additional error details and context
     """
 
-    def __init__(
-        self,
-        message: str,
-        exc: Optional[httpx.HTTPError] = None
-    ) -> None:
+    def __init__(self, message: str, exc: Optional[httpx.HTTPError] = None) -> None:
         """
         Initialize the base SDK exception.
 
@@ -169,6 +165,7 @@ class RequestError(IpsdkError):
         ...     print(f"Network error: {e}")
         ...     print(f"Failed request: {e.request.url}")
     """
+
     def __init__(self, exc: httpx.HTTPError) -> None:
         super().__init__(exc.args[0], exc)
 
@@ -218,6 +215,7 @@ class HTTPStatusError(IpsdkError):
         ...     elif e.response.status_code == 401:
         ...         print("Authentication failed")
     """
+
     def __init__(self, exc: httpx.HTTPError) -> None:
         super().__init__(exc.args[0], exc)
 

--- a/src/ipsdk/gateway.py
+++ b/src/ipsdk/gateway.py
@@ -117,6 +117,7 @@ class AsyncAuthMixin:
             logging.exception(exc)
             raise exceptions.RequestError(exc)
 
+
 Gateway = type("Gateway", (AuthMixin, connection.Connection), {})
 AsyncGateway = type("AsyncGateway", (AsyncAuthMixin, connection.AsyncConnection), {})
 

--- a/src/ipsdk/heuristics.py
+++ b/src/ipsdk/heuristics.py
@@ -9,6 +9,7 @@ identifiable information (PII) from log messages before they are written.
 """
 
 import re
+
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -34,9 +35,7 @@ class Scanner:
     _instance: Optional["Scanner"] = None
     _initialized: bool = False
 
-    def __new__(
-        cls, _custom_patterns: Optional[Dict[str, str]] = None
-    ) -> "Scanner":
+    def __new__(cls, _custom_patterns: Optional[Dict[str, str]] = None) -> "Scanner":
         """Create or return the singleton instance.
 
         Args:

--- a/src/ipsdk/http.py
+++ b/src/ipsdk/http.py
@@ -223,9 +223,7 @@ class Response:
             bool: True if the status code is in the 2xx range, False otherwise
         """
         return (
-            HTTPStatus.OK.value
-            <= self.status_code
-            < HTTPStatus.MULTIPLE_CHOICES.value
+            HTTPStatus.OK.value <= self.status_code < HTTPStatus.MULTIPLE_CHOICES.value
         )
 
     def is_error(self) -> bool:

--- a/src/ipsdk/jsonutils.py
+++ b/src/ipsdk/jsonutils.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import json
+
 from typing import Union
 
 from . import exceptions

--- a/src/ipsdk/logging.py
+++ b/src/ipsdk/logging.py
@@ -99,6 +99,7 @@ Example:
 import logging
 import sys
 import traceback
+
 from functools import partial
 from typing import Callable
 from typing import Dict
@@ -249,7 +250,6 @@ def _get_loggers() -> set[logging.Logger]:
         if name.startswith((metadata.name, "httpx")):
             loggers.add(logging.getLogger(name))
     return loggers
-
 
 
 def get_logger() -> logging.Logger:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import json
+
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -1135,7 +1136,6 @@ def test_response_json_with_non_dict_data():
 
 @pytest.mark.asyncio
 
-
 # --------- Missing Coverage Tests ---------
 
 
@@ -1145,6 +1145,7 @@ class TestAbstractMethodCoverage:
     @pytest.mark.asyncio
     async def test_async_connection_abstract_authenticate_method(self):
         """Test AsyncConnection abstract authenticate method."""
+
         # Create test class inheriting from AsyncConnection
         class TestAsyncConnection(AsyncConnection):
             def __init__(self):

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -117,10 +117,7 @@ class TestHTTPStatus:
     def test_status_code_comparison(self):
         """Test comparing status codes."""
         assert HTTPStatus.OK.value < HTTPStatus.NOT_FOUND.value
-        assert (
-            HTTPStatus.NOT_FOUND.value
-            < HTTPStatus.INTERNAL_SERVER_ERROR.value
-        )
+        assert HTTPStatus.NOT_FOUND.value < HTTPStatus.INTERNAL_SERVER_ERROR.value
         assert HTTPStatus.OK == HTTPStatus.OK
         assert HTTPStatus.OK != HTTPStatus.CREATED
 
@@ -363,7 +360,6 @@ class TestHTTPMethod:
         for method in non_idempotent:
             assert method.value in ["POST", "PATCH"]
 
-
         """Test that enum members cannot be deleted."""
         # Enums don't allow deleting members
         with pytest.raises(AttributeError):
@@ -515,12 +511,8 @@ class TestEnumsIntegration:
     def test_building_http_response_mapping(self):
         """Test building a response mapping with enums."""
         response_map = {
-            (HTTPMethod.GET, HTTPStatus.OK): (
-                "Resource retrieved successfully"
-            ),
-            (HTTPMethod.POST, HTTPStatus.CREATED): (
-                "Resource created successfully"
-            ),
+            (HTTPMethod.GET, HTTPStatus.OK): ("Resource retrieved successfully"),
+            (HTTPMethod.POST, HTTPStatus.CREATED): ("Resource created successfully"),
             (HTTPMethod.DELETE, HTTPStatus.NO_CONTENT): (
                 "Resource deleted successfully"
             ),

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -36,9 +36,7 @@ class TestIpsdkError:
         mock_response.status_code = 500
 
         httpx_exc = httpx.HTTPStatusError(
-            "Server error",
-            request=mock_request,
-            response=mock_response
+            "Server error", request=mock_request, response=mock_response
         )
 
         exc = exceptions.IpsdkError("Wrapped error", httpx_exc)
@@ -132,9 +130,7 @@ class TestHTTPStatusError:
         mock_response.status_code = 404
 
         httpx_exc = httpx.HTTPStatusError(
-            "Not found",
-            request=mock_request,
-            response=mock_response
+            "Not found", request=mock_request, response=mock_response
         )
         exc = exceptions.HTTPStatusError(httpx_exc)
 
@@ -152,9 +148,7 @@ class TestHTTPStatusError:
         mock_response.status_code = 400
 
         httpx_exc = httpx.HTTPStatusError(
-            "Bad request",
-            request=mock_request,
-            response=mock_response
+            "Bad request", request=mock_request, response=mock_response
         )
         exc = exceptions.HTTPStatusError(httpx_exc)
 
@@ -170,9 +164,7 @@ class TestHTTPStatusError:
         mock_response.status_code = 500
 
         httpx_exc = httpx.HTTPStatusError(
-            "Internal server error",
-            request=mock_request,
-            response=mock_response
+            "Internal server error", request=mock_request, response=mock_response
         )
         exc = exceptions.HTTPStatusError(httpx_exc)
 
@@ -187,9 +179,7 @@ class TestHTTPStatusError:
         mock_response.status_code = 403
 
         httpx_exc = httpx.HTTPStatusError(
-            "Forbidden",
-            request=mock_request,
-            response=mock_response
+            "Forbidden", request=mock_request, response=mock_response
         )
         exc = exceptions.HTTPStatusError(httpx_exc)
 
@@ -283,9 +273,7 @@ class TestExceptionHierarchy:
 
         httpx_request_exc = httpx.RequestError("Test", request=mock_request)
         httpx_status_exc = httpx.HTTPStatusError(
-            "Test",
-            request=mock_request,
-            response=mock_response
+            "Test", request=mock_request, response=mock_response
         )
 
         exception_instances = [
@@ -320,9 +308,7 @@ class TestExceptionHierarchy:
 
         httpx_request_exc = httpx.RequestError("Test", request=mock_request)
         httpx_status_exc = httpx.HTTPStatusError(
-            "Test",
-            request=mock_request,
-            response=mock_response
+            "Test", request=mock_request, response=mock_response
         )
 
         exceptions_to_test.append(exceptions.RequestError(httpx_request_exc))
@@ -430,9 +416,7 @@ class TestExceptionIntegration:
         for status_code in status_codes:
             mock_response.status_code = status_code
             httpx_err = httpx.HTTPStatusError(
-                f"HTTP {status_code}",
-                request=mock_request,
-                response=mock_response
+                f"HTTP {status_code}", request=mock_request, response=mock_response
             )
 
             sdk_err = exceptions.HTTPStatusError(httpx_err)
@@ -461,9 +445,7 @@ class TestBackwardCompatibility:
 
         httpx_request_exc = httpx.RequestError("Test", request=mock_request)
         httpx_status_exc = httpx.HTTPStatusError(
-            "Test",
-            request=mock_request,
-            response=mock_response
+            "Test", request=mock_request, response=mock_response
         )
 
         test_exceptions = [
@@ -491,9 +473,7 @@ class TestBackwardCompatibility:
         mock_response.text = "Not found"
 
         httpx_exc = httpx.HTTPStatusError(
-            "Not found",
-            request=mock_request,
-            response=mock_response
+            "Not found", request=mock_request, response=mock_response
         )
         sdk_exc = exceptions.HTTPStatusError(httpx_exc)
 

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -103,7 +103,9 @@ class TestScannerInitialization:
         ]
 
         for pattern_name in expected_patterns:
-            assert pattern_name in patterns, f"Expected pattern '{pattern_name}' not found"  # noqa: E501
+            assert pattern_name in patterns, (
+                f"Expected pattern '{pattern_name}' not found"
+            )
 
 
 class TestPatternManagement:
@@ -292,7 +294,10 @@ MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj
 -----END PRIVATE KEY-----"""
         result = scanner.scan_and_redact(text)
 
-        assert "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj" not in result  # noqa: E501
+        assert (
+            "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj"
+            not in result
+        )
         assert "[REDACTED_PRIVATE_KEY]" in result
 
 
@@ -613,7 +618,9 @@ class TestRealWorldScenarios:
         scanner = heuristics.Scanner()
 
         # Config-style format (not quoted JSON keys) that patterns can match
-        config_str = "username: admin, password: secret123, api_key: key_abcdef1234567890"  # noqa: E501
+        config_str = (
+            "username: admin, password: secret123, api_key: key_abcdef1234567890"
+        )
         result = scanner.scan_and_redact(config_str)
 
         assert "secret123" not in result

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,6 +4,7 @@
 """Tests for the ipsdk.__init__ module."""
 
 import ipsdk
+
 from ipsdk import gateway_factory
 from ipsdk import logging
 from ipsdk import metadata

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,6 +3,7 @@
 
 import logging
 import sys
+
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -144,6 +145,7 @@ class TestTraceFunction:
     def test_trace_function_with_callable(self):
         """Test trace function logs function name."""
         with patch("ipsdk.logging.log") as mock_log:
+
             def test_func():
                 pass
 
@@ -223,10 +225,9 @@ class TestFatalFunction:
 
     def test_fatal_function_logs_and_exits(self):
         """Test that fatal function logs message and exits."""
-        with patch("ipsdk.logging.log") as mock_log, \
-             patch("builtins.print") as mock_print, \
-             patch("sys.exit") as mock_exit:
-
+        with patch("ipsdk.logging.log") as mock_log, patch(
+            "builtins.print"
+        ) as mock_print, patch("sys.exit") as mock_exit:
             ipsdk_logging.fatal("fatal error")
 
             mock_log.assert_called_once_with(ipsdk_logging.FATAL, "fatal error")
@@ -238,10 +239,9 @@ class TestFatalFunction:
         messages = ["critical failure", "system error", "cannot continue"]
 
         for message in messages:
-            with patch("ipsdk.logging.log") as mock_log, \
-                 patch("builtins.print") as mock_print, \
-                 patch("sys.exit") as mock_exit:
-
+            with patch("ipsdk.logging.log") as mock_log, patch(
+                "builtins.print"
+            ) as mock_print, patch("sys.exit") as mock_exit:
                 ipsdk_logging.fatal(message)
 
                 mock_log.assert_called_once_with(ipsdk_logging.FATAL, message)
@@ -314,8 +314,9 @@ class TestSetLevel:
 
     def test_set_level_with_propagate(self):
         """Test set_level with propagate parameter."""
-        with patch("ipsdk.logging.get_logger") as mock_get_logger, \
-             patch("ipsdk.logging._get_loggers") as mock_get_loggers:
+        with patch("ipsdk.logging.get_logger") as mock_get_logger, patch(
+            "ipsdk.logging._get_loggers"
+        ) as mock_get_loggers:
             mock_logger = Mock()
             mock_get_logger.return_value = mock_logger
 
@@ -501,7 +502,11 @@ class TestSensitiveDataFiltering:
             test_cases = [
                 (ipsdk_logging.debug, logging.DEBUG, "Debug: password=testpass"),
                 (ipsdk_logging.info, logging.INFO, "Info: api_key=key1234567890abcdef"),
-                (ipsdk_logging.warning, logging.WARNING, "Warning: secret=sec1234567890abcdef"),  # noqa: E501
+                (
+                    ipsdk_logging.warning,
+                    logging.WARNING,
+                    "Warning: secret=sec1234567890abcdef",
+                ),
             ]
 
             for func, level, message in test_cases:
@@ -512,7 +517,10 @@ class TestSensitiveDataFiltering:
                 call_args = mock_logger.log.call_args[0]
                 assert call_args[0] == level
                 # The message should be redacted
-                assert "testpass" not in call_args[1] or "[REDACTED_PASSWORD]" in call_args[1]  # noqa: E501
+                assert (
+                    "testpass" not in call_args[1]
+                    or "[REDACTED_PASSWORD]" in call_args[1]
+                )
 
         # Cleanup
         ipsdk_logging.disable_sensitive_data_filtering()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import ipsdk.metadata
+
 from ipsdk import metadata
 
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -247,8 +247,6 @@ def test_authenticate_oauth_preferred_over_basic():
 
 
 @pytest.mark.asyncio
-
-
 @pytest.mark.asyncio
 async def test_async_authenticate_basicauth_success():
     """Test AsyncAuthMixin.authenticate_basicauth successful authentication."""


### PR DESCRIPTION
- Add blank line between import and from groups via lines-between-types setting
- Replace deprecated TRY200 rule with B904 in ignore list
- Reformat codebase to comply with updated isort rules