### PR TITLE
refactor: Add comprehensive logging.trace() calls with module and class context

### DIFF
--- a/src/ipsdk/connection.py
+++ b/src/ipsdk/connection.py
@@ -203,6 +203,7 @@ class ConnectionBase:
             timeout (int): The request timeout for sending requests to the
                 server.
         """
+        logging.trace(self.__init__, modname=__name__, clsname=self.__class__)
 
         self.user = user
         self.password = password
@@ -255,7 +256,7 @@ class ConnectionBase:
         Returns:
             A string that represents the full URL
         """
-        logging.trace(self._make_base_url)
+        logging.trace(self._make_base_url, modname=__name__, clsname=self.__class__)
 
         if port == 0:
             port = 443 if use_tls is True else 80
@@ -299,7 +300,7 @@ class ConnectionBase:
         Returns:
             A `httpx.Request` object that can be used to send to the server
         """
-        logging.trace(self._build_request)
+        logging.trace(self._build_request, modname=__name__, clsname=self.__class__)
 
         self._validate_request_args(method, path, params, json)
 
@@ -361,6 +362,9 @@ class ConnectionBase:
             IpsdkError: If method is not HTTPMethod type, params is not dict,
                 json is not dict/list, or path is not string
         """
+        logging.trace(
+            self._validate_request_args, modname=__name__, clsname=self.__class__
+        )
         if not isinstance(method, HTTPMethod):
             msg = "method must be of type `HTTPMethod`"
             raise exceptions.IpsdkError(msg)
@@ -425,7 +429,7 @@ class Connection(ConnectionBase):
         Returns:
             An instance of `httpx.Client`
         """
-        logging.trace(self.__init_client__)
+        logging.trace(self.__init_client__, modname=__name__, clsname=self.__class__)
         logging.info(f"Creating new client for {base_url}")
         return httpx.Client(
             base_url=base_url or "",
@@ -475,7 +479,7 @@ class Connection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self._send_request)
+        logging.trace(self._send_request, modname=__name__, clsname=self.__class__)
 
         if self.authenticated is not True:
             self.authenticate()
@@ -526,7 +530,7 @@ class Connection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.get)
+        logging.trace(self.get, modname=__name__, clsname=self.__class__)
         return self._send_request(HTTPMethod.GET, path=path, params=params)
 
     def delete(self, path: str, params: Optional[Dict[str, Any]] = None) -> Response:
@@ -548,7 +552,7 @@ class Connection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.delete)
+        logging.trace(self.delete, modname=__name__, clsname=self.__class__)
         return self._send_request(HTTPMethod.DELETE.value, path=path, params=params)
 
     def post(
@@ -581,7 +585,7 @@ class Connection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.post)
+        logging.trace(self.post, modname=__name__, clsname=self.__class__)
         return self._send_request(HTTPMethod.POST, path=path, params=params, json=json)
 
     def put(
@@ -614,7 +618,7 @@ class Connection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.put)
+        logging.trace(self.put, modname=__name__, clsname=self.__class__)
         return self._send_request(HTTPMethod.PUT, path=path, params=params, json=json)
 
     def patch(
@@ -647,7 +651,7 @@ class Connection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.patch)
+        logging.trace(self.patch, modname=__name__, clsname=self.__class__)
         return self._send_request(HTTPMethod.PATCH, path=path, params=params, json=json)
 
 
@@ -676,7 +680,7 @@ class AsyncConnection(ConnectionBase):
         Returns:
             An instance of `httpx.AsyncClient`
         """
-        logging.trace(self.__init_client__)
+        logging.trace(self.__init_client__, modname=__name__, clsname=self.__class__)
         logging.info(f"Creating new async client for {base_url}")
         return httpx.AsyncClient(
             base_url=base_url or "", verify=verify, timeout=timeout
@@ -724,7 +728,7 @@ class AsyncConnection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self._send_request)
+        logging.trace(self._send_request, modname=__name__, clsname=self.__class__)
 
         if self.authenticated is False:
             await self.authenticate()
@@ -775,7 +779,7 @@ class AsyncConnection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.get)
+        logging.trace(self.get, modname=__name__, clsname=self.__class__)
         return await self._send_request(HTTPMethod.GET, path=path, params=params)
 
     async def delete(
@@ -799,7 +803,7 @@ class AsyncConnection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.delete)
+        logging.trace(self.delete, modname=__name__, clsname=self.__class__)
         return await self._send_request(HTTPMethod.DELETE, path=path, params=params)
 
     async def post(
@@ -832,7 +836,7 @@ class AsyncConnection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.post)
+        logging.trace(self.post, modname=__name__, clsname=self.__class__)
         return await self._send_request(
             HTTPMethod.POST, path=path, params=params, json=json
         )
@@ -867,7 +871,7 @@ class AsyncConnection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.put)
+        logging.trace(self.put, modname=__name__, clsname=self.__class__)
         return await self._send_request(
             HTTPMethod.PUT, path=path, params=params, json=json
         )
@@ -902,7 +906,7 @@ class AsyncConnection(ConnectionBase):
         Returns:
             A `Response` object
         """
-        logging.trace(self.patch)
+        logging.trace(self.patch, modname=__name__, clsname=self.__class__)
         return await self._send_request(
             HTTPMethod.PATCH, path=path, params=params, json=json
         )

--- a/src/ipsdk/exceptions.py
+++ b/src/ipsdk/exceptions.py
@@ -78,6 +78,8 @@ from typing import Optional
 
 import httpx
 
+from . import logging
+
 
 class IpsdkError(Exception):
     """
@@ -98,6 +100,7 @@ class IpsdkError(Exception):
         Args:
             message (str): Human-readable error message
         """
+        logging.trace(self.__init__, modname=__name__, clsname=self.__class__)
         super().__init__(message)
         self._exc = exc
 
@@ -108,6 +111,7 @@ class IpsdkError(Exception):
         Returns:
             A formatted error message including details if available
         """
+        logging.trace(self.__str__, modname=__name__, clsname=self.__class__)
         return self.args[0]
 
     @property
@@ -167,6 +171,7 @@ class RequestError(IpsdkError):
     """
 
     def __init__(self, exc: httpx.HTTPError) -> None:
+        logging.trace(self.__init__, modname=__name__, clsname=self.__class__)
         super().__init__(exc.args[0], exc)
 
 
@@ -217,6 +222,7 @@ class HTTPStatusError(IpsdkError):
     """
 
     def __init__(self, exc: httpx.HTTPError) -> None:
+        logging.trace(self.__init__, modname=__name__, clsname=self.__class__)
         super().__init__(exc.args[0], exc)
 
 
@@ -275,6 +281,7 @@ def _detect_mock_side_effect(response_text: Any) -> None:
     Raises:
         _MockDetectionError: If a Mock with side_effect is detected
     """
+    logging.trace(_detect_mock_side_effect, modname=__name__)
     response_str = str(response_text)
     if (
         "Mock" in response_str

--- a/src/ipsdk/gateway.py
+++ b/src/ipsdk/gateway.py
@@ -165,6 +165,7 @@ def _make_path() -> str:
     Returns:
         A string that provides the login url
     """
+    logging.trace(_make_path, modname=__name__)
     return "/login"
 
 
@@ -181,6 +182,7 @@ def _make_body(user: str, password: str) -> dict[str, str]:
         A dict object that can be used to send in the body of the
             authentication request
     """
+    logging.trace(_make_body, modname=__name__)
     return {"username": user, "password": password}
 
 
@@ -191,6 +193,7 @@ def _make_headers() -> dict[str, str]:
     Returns:
         A dict object that can be passed to a request to set the headers
     """
+    logging.trace(_make_headers, modname=__name__)
     return {
         "Content-Type": "application/json",
         "Accept": "application/json",
@@ -211,6 +214,7 @@ class AuthMixin:
         """
         Provides the authentication function for authenticating to the server
         """
+        logging.trace(self.authenticate, modname=__name__, clsname=self.__class__)
         assert self.user is not None
         assert self.password is not None
 
@@ -245,6 +249,7 @@ class AsyncAuthMixin:
         """
         Provides the authentication function for authenticating to the server
         """
+        logging.trace(self.authenticate, modname=__name__, clsname=self.__class__)
         assert self.user is not None
         assert self.password is not None
 
@@ -320,6 +325,7 @@ def gateway_factory(
     Returns:
         An initialized connection instance
     """
+    logging.trace(gateway_factory, modname=__name__)
 
     factory = AsyncGateway if want_async is True else Gateway
     return factory(

--- a/src/ipsdk/heuristics.py
+++ b/src/ipsdk/heuristics.py
@@ -16,6 +16,8 @@ from typing import List
 from typing import Optional
 from typing import Pattern
 
+from . import logging
+
 
 class Scanner:
     """Scanner for detecting and redacting sensitive data patterns in text.
@@ -190,6 +192,7 @@ class Scanner:
         Raises:
             None
         """
+        logging.trace(self.remove_pattern, modname=__name__, clsname=self.__class__)
         if name in self._patterns:
             del self._patterns[name]
             del self._redaction_functions[name]
@@ -205,6 +208,7 @@ class Scanner:
         Raises:
             None
         """
+        logging.trace(self.list_patterns, modname=__name__, clsname=self.__class__)
         return list(self._patterns.keys())
 
     def scan_and_redact(self, text: str) -> str:
@@ -262,6 +266,9 @@ class Scanner:
         Raises:
             None
         """
+        logging.trace(
+            self.get_sensitive_data_types, modname=__name__, clsname=self.__class__
+        )
         if not text:
             return []
 
@@ -286,6 +293,7 @@ class Scanner:
         Raises:
             None
         """
+        logging.trace(cls.reset_singleton, modname=__name__, clsname=cls)
         cls._instance = None
         cls._initialized = False
 
@@ -323,6 +331,7 @@ def configure_scanner(
     Raises:
         re.error: If any custom patterns are invalid.
     """
+    logging.trace(configure_scanner, modname=__name__)
     # Reset the singleton to allow reconfiguration
     Scanner.reset_singleton()
     return Scanner(custom_patterns)

--- a/src/ipsdk/http.py
+++ b/src/ipsdk/http.py
@@ -16,6 +16,8 @@ from typing import Union
 
 import httpx
 
+from . import logging
+
 # Import HTTPMethod from standard library (Python 3.11+) or define fallback
 try:
     from http import HTTPMethod
@@ -80,6 +82,7 @@ class Request:
         headers: Optional[Dict[str, str]] = None,
         json: Optional[Union[str, bytes, dict, list]] = None,
     ) -> None:
+        logging.trace(self.__init__, modname=__name__, clsname=self.__class__)
         self.method = method
         self.path = path
         self.params = params or {}
@@ -103,6 +106,7 @@ class Request:
         Returns:
             str: A string representation of the request
         """
+        logging.trace(self.__repr__, modname=__name__, clsname=self.__class__)
         return f"Request(method='{self.method}', path='{self.path}')"
 
 
@@ -124,6 +128,7 @@ class Response:
     """
 
     def __init__(self, httpx_response: httpx.Response) -> None:
+        logging.trace(self.__init__, modname=__name__, clsname=self.__class__)
         if httpx_response is None:
             msg = "httpx_response cannot be None"
             raise ValueError(msg)
@@ -200,6 +205,7 @@ class Response:
         Raises:
             ValueError: If the response content is not valid JSON
         """
+        logging.trace(self.json, modname=__name__, clsname=self.__class__)
         try:
             return self._response.json()
         except Exception as exc:
@@ -213,6 +219,7 @@ class Response:
         Raises:
             httpx.HTTPStatusError: If the response status code indicates an error
         """
+        logging.trace(self.raise_for_status, modname=__name__, clsname=self.__class__)
         self._response.raise_for_status()
 
     def is_success(self) -> bool:
@@ -222,6 +229,7 @@ class Response:
         Returns:
             bool: True if the status code is in the 2xx range, False otherwise
         """
+        logging.trace(self.is_success, modname=__name__, clsname=self.__class__)
         return (
             HTTPStatus.OK.value <= self.status_code < HTTPStatus.MULTIPLE_CHOICES.value
         )
@@ -233,6 +241,7 @@ class Response:
         Returns:
             bool: True if the status code indicates an error, False otherwise
         """
+        logging.trace(self.is_error, modname=__name__, clsname=self.__class__)
         return self.status_code >= HTTPStatus.BAD_REQUEST.value
 
     def __repr__(self) -> str:
@@ -242,4 +251,5 @@ class Response:
         Returns:
             str: A string representation of the response
         """
+        logging.trace(self.__repr__, modname=__name__, clsname=self.__class__)
         return f"Response(status_code={self.status_code}, url='{self.url}')"

--- a/src/ipsdk/jsonutils.py
+++ b/src/ipsdk/jsonutils.py
@@ -121,6 +121,7 @@ def loads(s: str) -> Union[dict, list]:
     Returns:
         A dict or list object
     """
+    logging.trace(loads, modname=__name__)
     try:
         return json.loads(s)
     except json.JSONDecodeError as exc:
@@ -142,6 +143,7 @@ def dumps(o: Union[dict, list]) -> str:
     Returns:
         A JSON string representation
     """
+    logging.trace(dumps, modname=__name__)
     try:
         return json.dumps(o)
     except (TypeError, ValueError) as exc:

--- a/src/ipsdk/logging.py
+++ b/src/ipsdk/logging.py
@@ -175,7 +175,11 @@ error = partial(log, logging.ERROR)
 critical = partial(log, logging.CRITICAL)
 
 
-def trace(f: Callable) -> None:
+def trace(
+    f: Callable,
+    modname: Optional[str] = None,
+    clsname: Optional[str] = None
+) -> None:
     """Log a trace message for function invocation.
 
     This function logs a trace-level message indicating that a function
@@ -190,7 +194,17 @@ def trace(f: Callable) -> None:
     Raises:
         None
     """
-    log(logging.TRACE, f"invoking {f.__name__}")
+    msg = ""
+
+    if modname is not None:
+        msg += f"{modname}."
+
+    if clsname is not None:
+        msg += f"{clsname.__name__}."
+
+    msg += f.__name__
+
+    log(logging.TRACE, msg)
 
 
 def exception(exc: Exception) -> None:

--- a/src/ipsdk/platform.py
+++ b/src/ipsdk/platform.py
@@ -246,6 +246,7 @@ def _make_oauth_headers() -> dict[str, str]:
     Raises:
         None
     """
+    logging.trace(_make_oauth_headers, modname=__name__)
     return {"Content-Type": "application/x-www-form-urlencoded"}
 
 
@@ -265,6 +266,7 @@ def _make_oauth_path() -> str:
     Raises:
         None
     """
+    logging.trace(_make_oauth_path, modname=__name__)
     return "/oauth/token"
 
 
@@ -286,6 +288,7 @@ def _make_oauth_body(client_id: str, client_secret: str) -> dict[str, str]:
     Raises:
         None
     """
+    logging.trace(_make_oauth_body, modname=__name__)
     return {
         "grant_type": "client_credentials",
         "client_id": client_id,
@@ -311,6 +314,7 @@ def _make_basicauth_body(user: str, password: str) -> dict[str, dict[str, str]]:
     Raises:
         None
     """
+    logging.trace(_make_basicauth_body, modname=__name__)
     return {
         "user": {
             "username": user,
@@ -335,6 +339,7 @@ def _make_basicauth_path() -> str:
     Raises:
         None
     """
+    logging.trace(_make_basicauth_path, modname=__name__)
     return "/login"
 
 
@@ -355,6 +360,7 @@ class AuthMixin:
         """
         Provides the authentication function for authenticating to the server
         """
+        logging.trace(self.authenticate, modname=__name__, clsname=self.__class__)
         if self.client_id is not None and self.client_secret is not None:
             self.authenticate_oauth()
         elif self.user is not None and self.password is not None:
@@ -372,6 +378,7 @@ class AuthMixin:
         """
         Performs authentication for basic authorization
         """
+        logging.trace(self.authenticate_user, modname=__name__, clsname=self.__class__)
         logging.info("Attempting to perform basic authentication")
 
         assert self.user is not None
@@ -395,6 +402,7 @@ class AuthMixin:
         """
         Performs authentication for OAuth client credentials
         """
+        logging.trace(self.authenticate_oauth, modname=__name__, clsname=self.__class__)
         logging.info("Attempting to perform oauth authentication")
 
         assert self.client_id is not None
@@ -442,6 +450,7 @@ class AsyncAuthMixin:
         """
         Provides the authentication function for authenticating to the server
         """
+        logging.trace(self.authenticate, modname=__name__, clsname=self.__class__)
         if self.client_id is not None and self.client_secret is not None:
             await self.authenticate_oauth()
 
@@ -461,6 +470,9 @@ class AsyncAuthMixin:
         """
         Performs authentication for basic authorization
         """
+        logging.trace(
+            self.authenticate_basicauth, modname=__name__, clsname=self.__class__
+        )
         logging.info("Attempting to perform basic authentication")
 
         assert self.user is not None
@@ -484,6 +496,7 @@ class AsyncAuthMixin:
         """
         Performs authentication for OAuth client credentials
         """
+        logging.trace(self.authenticate_oauth, modname=__name__, clsname=self.__class__)
         logging.info("Attempting to perform oauth authentication")
 
         assert self.client_id is not None
@@ -573,6 +586,7 @@ def platform_factory(
     Returns:
         Platform: An initialized Platform connection instance.
     """
+    logging.trace(platform_factory, modname=__name__)
 
     factory = AsyncPlatform if want_async is True else Platform
     return factory(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -150,7 +150,7 @@ class TestTraceFunction:
                 pass
 
             ipsdk_logging.trace(test_func)
-            mock_log.assert_called_once_with(logging.TRACE, "invoking test_func")
+            mock_log.assert_called_once_with(logging.TRACE, "test_func")
 
     def test_trace_function_with_different_functions(self):
         """Test trace function with different function types."""
@@ -168,9 +168,9 @@ class TestTraceFunction:
                     pass
 
             test_cases = [
-                (regular_func, "invoking regular_func"),
-                (TestClass.method, "invoking method"),
-                (TestClass.static_method, "invoking static_method"),
+                (regular_func, "regular_func"),
+                (TestClass.method, "method"),
+                (TestClass.static_method, "static_method"),
             ]
 
             for func, expected_msg in test_cases:
@@ -654,7 +654,7 @@ class TestIntegration:
             ipsdk_logging.trace(test_function)
 
         messages = [record.getMessage() for record in caplog.records]
-        assert any("invoking test_function" in msg for msg in messages)
+        assert any("test_function" in msg for msg in messages)
 
 
 class TestFormatString:


### PR DESCRIPTION
- Add logging.trace() as first call in all functions and methods across codebase
- Include modname=__name__ parameter for module-level functions
- Include modname=__name__ and clsname=self.__class__ for instance methods
- Include modname=__name__ and clsname=cls for class methods
- Update trace() function to build fully qualified names (module.Class.method)
- Exclude property getters to prevent recursion issues
- Exclude heuristics methods called by logging module to prevent circular dependencies