### PR TITLE
refactor: Replace assert statements with proper runtime validation

### DIFF
--- a/src/ipsdk/gateway.py
+++ b/src/ipsdk/gateway.py
@@ -215,8 +215,9 @@ class AuthMixin:
         Provides the authentication function for authenticating to the server
         """
         logging.trace(self.authenticate, modname=__name__, clsname=self.__class__)
-        assert self.user is not None
-        assert self.password is not None
+        if self.user is None or self.password is None:
+            msg = "Username and password are required for Gateway authentication"
+            raise exceptions.IpsdkError(msg)
 
         data = _make_body(self.user, self.password)
         headers = _make_headers()
@@ -250,8 +251,9 @@ class AsyncAuthMixin:
         Provides the authentication function for authenticating to the server
         """
         logging.trace(self.authenticate, modname=__name__, clsname=self.__class__)
-        assert self.user is not None
-        assert self.password is not None
+        if self.user is None or self.password is None:
+            msg = "Username and password are required for Gateway authentication"
+            raise exceptions.IpsdkError(msg)
 
         data = _make_body(self.user, self.password)
         headers = _make_headers()

--- a/src/ipsdk/platform.py
+++ b/src/ipsdk/platform.py
@@ -381,8 +381,10 @@ class AuthMixin:
         logging.trace(self.authenticate_user, modname=__name__, clsname=self.__class__)
         logging.info("Attempting to perform basic authentication")
 
-        assert self.user is not None
-        assert self.password is not None
+        if self.user is None or self.password is None:
+            msg = "Username and password are required for basic authentication"
+            raise exceptions.IpsdkError(msg)
+
         data = _make_basicauth_body(self.user, self.password)
         path = _make_basicauth_path()
 
@@ -405,8 +407,10 @@ class AuthMixin:
         logging.trace(self.authenticate_oauth, modname=__name__, clsname=self.__class__)
         logging.info("Attempting to perform oauth authentication")
 
-        assert self.client_id is not None
-        assert self.client_secret is not None
+        if self.client_id is None or self.client_secret is None:
+            msg = "Client ID and client secret are required for OAuth authentication"
+            raise exceptions.IpsdkError(msg)
+
         data = _make_oauth_body(self.client_id, self.client_secret)
         headers = _make_oauth_headers()
         path = _make_oauth_path()
@@ -475,8 +479,10 @@ class AsyncAuthMixin:
         )
         logging.info("Attempting to perform basic authentication")
 
-        assert self.user is not None
-        assert self.password is not None
+        if self.user is None or self.password is None:
+            msg = "Username and password are required for basic authentication"
+            raise exceptions.IpsdkError(msg)
+
         data = _make_basicauth_body(self.user, self.password)
         path = _make_basicauth_path()
 
@@ -499,8 +505,10 @@ class AsyncAuthMixin:
         logging.trace(self.authenticate_oauth, modname=__name__, clsname=self.__class__)
         logging.info("Attempting to perform oauth authentication")
 
-        assert self.client_id is not None
-        assert self.client_secret is not None
+        if self.client_id is None or self.client_secret is None:
+            msg = "Client ID and client secret are required for OAuth authentication"
+            raise exceptions.IpsdkError(msg)
+
         data = _make_oauth_body(self.client_id, self.client_secret)
         headers = _make_oauth_headers()
         path = _make_oauth_path()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -268,19 +268,19 @@ def test_auth_mixin_assertion_errors():
     # Test with no user
     mixin.user = None
     mixin.password = "password"
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.IpsdkError):
         mixin.authenticate()
 
     # Test with no password
     mixin.user = "user"
     mixin.password = None
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.IpsdkError):
         mixin.authenticate()
 
     # Test with both None
     mixin.user = None
     mixin.password = None
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.IpsdkError):
         mixin.authenticate()
 
 
@@ -292,19 +292,19 @@ async def test_async_auth_mixin_assertion_errors():
     # Test with no user
     mixin.user = None
     mixin.password = "password"
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.IpsdkError):
         await mixin.authenticate()
 
     # Test with no password
     mixin.user = "user"
     mixin.password = None
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.IpsdkError):
         await mixin.authenticate()
 
     # Test with both None
     mixin.user = None
     mixin.password = None
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.IpsdkError):
         await mixin.authenticate()
 
 


### PR DESCRIPTION
- Replace assert statements in platform.py authentication methods with IpsdkError exceptions
- Replace assert statements in gateway.py authentication methods with IpsdkError exceptions
- Update test expectations to expect IpsdkError instead of AssertionError
- Add descriptive error messages for missing authentication credentials
- Ensure validation cannot be disabled with Python -O flag