### PR TITLE
refactor: Remove unused mock detection logic from exceptions module

### DIFF
--- a/src/ipsdk/exceptions.py
+++ b/src/ipsdk/exceptions.py
@@ -265,28 +265,3 @@ class SerializationError(IpsdkError):
         ... except SerializationError as e:
         ...     print(f"JSON serialization failed: {e}")
     """
-
-
-class _MockDetectionError(Exception):
-    """Internal exception for detecting Mock objects with side effects."""
-
-
-def _detect_mock_side_effect(response_text: Any) -> None:
-    """
-    Detect Mock objects with side effects and raise an exception for test handling.
-
-    Args:
-        response_text: The response text object to check
-
-    Raises:
-        _MockDetectionError: If a Mock with side_effect is detected
-    """
-    logging.trace(_detect_mock_side_effect, modname=__name__)
-    response_str = str(response_text)
-    if (
-        "Mock" in response_str
-        and hasattr(response_text, "side_effect")
-        and response_text.side_effect is not None
-    ):
-        mock_detected_msg = "Mock side_effect detected"
-        raise _MockDetectionError(mock_detected_msg)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -227,41 +227,6 @@ class TestSerializationError:
             assert str(e) == "Test"
 
 
-class TestInternalFunctions:
-    """Test cases for internal helper functions."""
-
-    def test_detect_mock_side_effect_with_mock(self):
-        """Test _detect_mock_side_effect detects mocks with side effects."""
-        mock_obj = Mock()
-        mock_obj.side_effect = Exception("test")
-
-        with pytest.raises(exceptions._MockDetectionError):
-            exceptions._detect_mock_side_effect(mock_obj)
-
-    def test_detect_mock_side_effect_with_mock_no_side_effect(self):
-        """Test _detect_mock_side_effect ignores mocks without side effects."""
-        mock_obj = Mock()
-        mock_obj.side_effect = None
-
-        # Should not raise an exception
-        exceptions._detect_mock_side_effect(mock_obj)
-
-    def test_detect_mock_side_effect_with_regular_string(self):
-        """Test _detect_mock_side_effect with regular string."""
-        regular_string = "This is just a regular string"
-
-        # Should not raise an exception
-        exceptions._detect_mock_side_effect(regular_string)
-
-    def test_detect_mock_side_effect_with_mock_like_string(self):
-        """Test _detect_mock_side_effect with string containing 'Mock'."""
-        # String contains "Mock" but is not actually a Mock object
-        mock_like_string = "This Mock string should not trigger"
-
-        # Should not raise an exception
-        exceptions._detect_mock_side_effect(mock_like_string)
-
-
 class TestExceptionHierarchy:
     """Test cases for the overall exception hierarchy."""
 


### PR DESCRIPTION
- Remove _MockDetectionError exception class from exceptions.py
- Remove _detect_mock_side_effect() helper function
- Remove TestInternalFunctions test class with 4 associated tests
- Simplify codebase by eliminating unnecessary mock-specific code