### PR TITLE
refactor: Improve tox configuration and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,26 +6,35 @@
 .DEFAULT_GOAL := help
 
 .PHONY: test coverage clean lint format ruff-fix security tox \
-		tox-py310 tox-py311 tox-py312 tox-py313
+		tox-py310 tox-py311 tox-py312 tox-py313 tox-coverage tox-lint \
+		tox-format tox-security tox-premerge tox-list
 
 # The help target displays a help message that includes the avialable targets
 # in this `Makefile`.  It is the default target if `make` is run without any
 # parameters.
 help:
 	@echo "Available targets:"
-	@echo "  clean        - Cleans the development environment"
-	@echo "  coverage     - Run test coverage report"
-	@echo "  format       - Format source files with ruff"
-	@echo "  lint         - Run analysis on source files"
-	@echo "  premerge     - Run the permerge tests locallly"
-	@echo "  ruff-fix     - Run ruff with --fix to auto-fix issues"
-	@echo "  security     - Run security analysis using bandit"
-	@echo "  test         - Run test suite"
-	@echo "  tox          - Run tests across all Python versions (3.10-3.13)"
-	@echo "  tox-py310    - Run tests with Python 3.10"
-	@echo "  tox-py311    - Run tests with Python 3.11"
-	@echo "  tox-py312    - Run tests with Python 3.12"
-	@echo "  tox-py313    - Run tests with Python 3.13"
+	@echo "  clean           - Cleans the development environment"
+	@echo "  coverage        - Run test coverage report"
+	@echo "  format          - Format source files with ruff"
+	@echo "  lint            - Run analysis on source files"
+	@echo "  premerge        - Run the premerge tests locally"
+	@echo "  ruff-fix        - Run ruff with --fix to auto-fix issues"
+	@echo "  security        - Run security analysis using bandit"
+	@echo "  test            - Run test suite"
+	@echo ""
+	@echo "Tox targets:"
+	@echo "  tox            - Run tests across all Python versions (3.10-3.13)"
+	@echo "  tox-py310      - Run tests with Python 3.10"
+	@echo "  tox-py311      - Run tests with Python 3.11"
+	@echo "  tox-py312      - Run tests with Python 3.12"
+	@echo "  tox-py313      - Run tests with Python 3.13"
+	@echo "  tox-coverage   - Run tests with coverage report using tox"
+	@echo "  tox-lint       - Run linting checks using tox"
+	@echo "  tox-format     - Format code using tox"
+	@echo "  tox-security   - Run security analysis using tox"
+	@echo "  tox-premerge   - Run all premerge checks using tox"
+	@echo "  tox-list       - List all available tox environments"
 	@echo ""
 
 # The test target will invoke the unit tests using pytest.   This target
@@ -90,3 +99,27 @@ tox-py312:
 # The tox-py313 target will run tests specifically with Python 3.13
 tox-py313:
 	uv run tox -e py313
+
+# The tox-coverage target will run tests with coverage report using tox
+tox-coverage:
+	uv run tox -e coverage
+
+# The tox-lint target will run linting checks using tox
+tox-lint:
+	uv run tox -e lint
+
+# The tox-format target will format code using tox
+tox-format:
+	uv run tox -e format
+
+# The tox-security target will run security analysis using tox
+tox-security:
+	uv run tox -e security
+
+# The tox-premerge target will run all premerge checks using tox
+tox-premerge:
+	uv run tox -e premerge
+
+# The tox-list target will list all available tox environments
+tox-list:
+	uv run tox list

--- a/tox.ini
+++ b/tox.ini
@@ -1,68 +1,110 @@
-# Tox configuration for Itential Python SDK
-# Runs premerge tests across multiple Python versions
+# tox configuration for ipsdk
+# This configuration uses tox-uv for faster dependency resolution and installation
 
 [tox]
 # Define test environments for Python 3.10, 3.11, 3.12, and 3.13
 envlist = py310,py311,py312,py313
-# Skip missing interpreters (useful when not all versions are installed)
-skip_missing_interpreters = true
-# Use uv for faster dependency management
-requires = tox-uv
+min_version = 4.0
+# Use uv for package installation (requires tox-uv plugin)
+requires =
+    tox>=4.0
+    tox-uv>=1.0.0
 
 [testenv]
-# Use uv as the package installer via tox-uv plugin
-runner = uv-venv-lock-runner
-# Install dependencies from uv's dependency groups using --group flag
-uv_sync_flags =
-    --group
-    dev
-# Commands to run for each environment (matches premerge target)
+# Use uv for package management
+runner = uv-venv-runner
+
+# Install the package in development mode
+package = wheel
+
+# Dependencies required for testing
+deps =
+    pytest>=7.0.0
+    pytest-cov>=4.0.0
+    pytest-asyncio>=0.21.0
+
+# Commands to run tests
 commands =
-    # Clean build artifacts
-    python -c "import shutil; import pathlib; [shutil.rmtree(p, ignore_errors=True) for p in ['.pytest_cache', 'htmlcov', 'dist', 'build'] + list(pathlib.Path('.').rglob('*.egg-info')) + list(pathlib.Path('.').rglob('__pycache__'))]"
-    # Run linting checks
-    ruff check src/ipsdk
-    ruff check tests
-    # Run security analysis
-    bandit -r src/ipsdk --configfile pyproject.toml
-    # Run tests
-    pytest tests -v
+    pytest tests -v -s {posargs}
+
+# Set environment variables
+setenv =
+    PYTHONPATH = {toxinidir}/src
+
+# Pass through these environment variables from the host
+passenv =
+    HOME
+    USER
+    PATH
+    TERM
 
 [testenv:py310]
 basepython = python3.10
+description = Run tests with Python 3.10
 
 [testenv:py311]
 basepython = python3.11
+description = Run tests with Python 3.11
 
 [testenv:py312]
 basepython = python3.12
+description = Run tests with Python 3.12
 
 [testenv:py313]
 basepython = python3.13
+description = Run tests with Python 3.13
 
-# Coverage environment for generating coverage reports
 [testenv:coverage]
+# Special environment for running tests with coverage
 basepython = python3.13
-uv_sync_flags =
-    --group
-    dev
+description = Run tests with coverage report
 commands =
-    pytest --cov=src/ipsdk --cov-report=term --cov-report=html tests/
+    pytest --cov=src/ipsdk --cov-report=term --cov-report=html tests/ {posargs}
 
-# Format environment for code formatting
+[testenv:lint]
+# Environment for running linting checks
+basepython = python3.13
+description = Run code quality checks (ruff)
+skip_install = true
+deps =
+    ruff
+commands =
+    ruff check src/ipsdk
+    ruff check tests
+
 [testenv:format]
+# Environment for formatting code
 basepython = python3.13
-uv_sync_flags =
-    --group
-    dev
+description = Format code with ruff
+skip_install = true
+deps =
+    ruff
 commands =
-    ruff format src/ipsdk tests
+    ruff format src/ipsdk
+    ruff format tests
 
-# Quick environment for running only tests (no lint/security)
-[testenv:quick]
+[testenv:security]
+# Environment for security analysis
 basepython = python3.13
-uv_sync_flags =
-    --group
-    dev
+description = Run security analysis with bandit
+skip_install = true
+deps =
+    bandit[toml]
 commands =
-    pytest tests -v
+    bandit -r src/ipsdk --configfile pyproject.toml
+
+[testenv:premerge]
+# Environment that runs all premerge checks
+basepython = python3.13
+description = Run all premerge checks (lint, security, test)
+deps =
+    pytest>=7.0.0
+    pytest-cov>=4.0.0
+    pytest-asyncio>=0.21.0
+    ruff
+    bandit[toml]
+commands =
+    ruff check src/ipsdk
+    ruff check tests
+    bandit -r src/ipsdk --configfile pyproject.toml
+    pytest tests -v -s


### PR DESCRIPTION
- Switch from uv-venv-lock-runner to uv-venv-runner for simpler setup
- Add explicit deps declarations replacing uv_sync_flags
- Add new tox environments: lint, security, premerge
- Add skip_install=true for non-package environments
- Add environment descriptions for better clarity
- Add new Makefile targets: tox-coverage, tox-lint, tox-format, tox-security, tox-premerge, tox-list
- Organize help output with separate Tox targets section
- Align with netsdk reference implementation